### PR TITLE
Harden disconnect refunds and fallback payouts

### DIFF
--- a/.github/workflows/temp-branch-ci.yml
+++ b/.github/workflows/temp-branch-ci.yml
@@ -1,0 +1,43 @@
+name: Temporary branch CI (fallback-refunds-and-payouts)
+
+# TEMPORARY: added only to give this branch an authoritative build/test
+# environment while local Gradle dependency resolution is unavailable.
+# Must be removed before this branch is merged into main.
+
+on:
+  push:
+    branches:
+      - fallback-refunds-and-payouts
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Build and test
+        run: ./gradlew clean build --stacktrace
+
+      - name: Upload build/test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-reports
+          path: |
+            build/reports
+            build/test-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,20 @@ repositories {
 
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("org.jetbrains:annotations:24.1.0")
     compileOnly ('com.github.MilkBowl:VaultAPI:1.7') {
         exclude group: 'org.bukkit'
     }
     implementation files('libs/lib-1.0-SNAPSHOT.jar')  
+
+    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.mockito:mockito-core:5.15.2"
+    testImplementation("org.spigotmc:spigot-api:1.21.11-R0.1-SNAPSHOT")
+    testImplementation("org.jetbrains:annotations:24.1.0")
+    testImplementation('com.github.MilkBowl:VaultAPI:1.7') {
+        exclude group: 'org.bukkit'
+    }
 }
 
 def targetJavaVersion = 21
@@ -48,6 +58,10 @@ tasks.withType(JavaCompile).configureEach {
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {
         options.release.set(targetJavaVersion)
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 processResources {

--- a/src/main/java/org/nc/nccasino/Nccasino.java
+++ b/src/main/java/org/nc/nccasino/Nccasino.java
@@ -61,6 +61,8 @@ import org.nc.nccasino.currency.CurrencyManager;
 import org.nc.nccasino.currency.CurrencyMode;
 import org.nc.nccasino.currency.DealerCurrencySettings;
 import org.nc.nccasino.payout.PendingPayoutStore;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
 import org.bukkit.Chunk;
 import org.bukkit.entity.EntityType;
 
@@ -85,6 +87,11 @@ public final class Nccasino extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
+        // Settle every active player session (refund/cash-out/forfeit as
+        // appropriate, exactly like a disconnect) before the scheduled
+        // tasks that would otherwise resolve in-flight rounds get
+        // cancelled along with everything else the plugin owns.
+        SessionRegistry.terminateAll(ExitReason.PLUGIN_DISABLE);
         savePreferences();
     }
 

--- a/src/main/java/org/nc/nccasino/Nccasino.java
+++ b/src/main/java/org/nc/nccasino/Nccasino.java
@@ -60,6 +60,7 @@ import org.nc.nccasino.economy.VaultHook;
 import org.nc.nccasino.currency.CurrencyManager;
 import org.nc.nccasino.currency.CurrencyMode;
 import org.nc.nccasino.currency.DealerCurrencySettings;
+import org.nc.nccasino.currency.MoneyHelper;
 import org.nc.nccasino.payout.PendingPayoutStore;
 import org.nc.nccasino.session.ExitReason;
 import org.nc.nccasino.session.SessionRegistry;
@@ -596,12 +597,12 @@ public final class Nccasino extends JavaPlugin implements Listener {
         return getCurrencyMode(internalName) == CurrencyMode.VAULT;
     }
 
-    /** Format wager amount for UI: VAULT → "$5", else → "5 emeralds" (lowercase, plural). Use this overload with cached mode/name to avoid config read per call. */
+    /** Format wager amount for UI: VAULT → "$5.00", else → "5 emeralds" (lowercase, plural). Use this overload with cached mode/name to avoid config read per call. */
     public String formatWagerDisplay(CurrencyMode mode, String currencyName, double amount) {
-        int n = (int) amount;
         if (mode == CurrencyMode.VAULT) {
-            return "$" + n;
+            return "$" + MoneyHelper.roundDisplay(MoneyHelper.bd(amount)).toPlainString();
         }
+        int n = (int) amount;
         String name = currencyName != null ? currencyName.toLowerCase() : "emerald";
         return n + " " + name + (n != 1 ? "s" : "");
     }
@@ -611,12 +612,12 @@ public final class Nccasino extends JavaPlugin implements Listener {
         return formatWagerDisplay(getCurrencyMode(internalName), getCurrencyName(internalName), amount);
     }
 
-    /** Chip button display name: VAULT → "$5", else → "5 Emeralds". Use with cached mode/name to avoid config read per call. */
+    /** Chip button display name: VAULT → "$5.00", else → "5 Emeralds". Use with cached mode/name to avoid config read per call. */
     public String getChipDisplayName(CurrencyMode mode, String currencyName, double value) {
-        int n = (int) value;
         if (mode == CurrencyMode.VAULT) {
-            return "$" + n;
+            return "$" + MoneyHelper.roundDisplay(MoneyHelper.bd(value)).toPlainString();
         }
+        int n = (int) value;
         String name = currencyName != null ? currencyName : "Emerald";
         return n + " " + name + (n != 1 ? "s" : "");
     }

--- a/src/main/java/org/nc/nccasino/Nccasino.java
+++ b/src/main/java/org/nc/nccasino/Nccasino.java
@@ -60,6 +60,7 @@ import org.nc.nccasino.economy.VaultHook;
 import org.nc.nccasino.currency.CurrencyManager;
 import org.nc.nccasino.currency.CurrencyMode;
 import org.nc.nccasino.currency.DealerCurrencySettings;
+import org.nc.nccasino.payout.PendingPayoutStore;
 import org.bukkit.Chunk;
 import org.bukkit.entity.EntityType;
 
@@ -74,6 +75,7 @@ public final class Nccasino extends JavaPlugin implements Listener {
     private String currencyName;  // Display name for the currency
     private VaultHook vaultHook;
     private CurrencyManager currencyManager;
+    private PendingPayoutStore pendingPayoutStore;
 
     /**
      * This local map was used in your code. If you still need it,
@@ -102,6 +104,9 @@ public final class Nccasino extends JavaPlugin implements Listener {
 
         // Phase 0 currency scaffolding (unused by gameplay until wired into games)
         currencyManager = new CurrencyManager(this);
+
+        // Durable pending-payout storage (delivered on join once wired up)
+        pendingPayoutStore = new PendingPayoutStore(this);
 
         // Register event listeners
         getServer().getPluginManager().registerEvents(new DealerInteractListener(this), this);
@@ -389,6 +394,10 @@ public final class Nccasino extends JavaPlugin implements Listener {
 
     public CurrencyManager getCurrencyManager() {
         return currencyManager;
+    }
+
+    public PendingPayoutStore getPendingPayoutStore() {
+        return pendingPayoutStore;
     }
 
     private void reinitializeDealers() {

--- a/src/main/java/org/nc/nccasino/Nccasino.java
+++ b/src/main/java/org/nc/nccasino/Nccasino.java
@@ -53,6 +53,7 @@ import org.nc.nccasino.listeners.DealerDeathHandler;
 import org.nc.nccasino.listeners.DealerEventListener;
 import org.nc.nccasino.listeners.DealerInitializeListener;
 import org.nc.nccasino.listeners.DealerInteractListener;
+import org.nc.nccasino.listeners.PlayerSessionListener;
 import org.nc.nccasino.entities.JockeyManager;
 import org.nc.nccasino.entities.JockeyNode;
 import org.nc.nccasino.economy.VaultHook;
@@ -108,6 +109,7 @@ public final class Nccasino extends JavaPlugin implements Listener {
         getServer().getPluginManager().registerEvents(new DealerDeathHandler(this), this);
         getServer().getPluginManager().registerEvents(new DealerEventListener(), this);
         getServer().getPluginManager().registerEvents(new DealerInitializeListener(this), this); // Register the chunk listener
+        getServer().getPluginManager().registerEvents(new PlayerSessionListener(this), this);
 
 
         // Register the command executor

--- a/src/main/java/org/nc/nccasino/components/AdminMenu.java
+++ b/src/main/java/org/nc/nccasino/components/AdminMenu.java
@@ -1587,20 +1587,39 @@ public class AdminMenu extends Menu {
 
     @Override
     public void cleanup() {
-        // 1) Unregister all event handlers for this instance
+        // Unregister this specific instance's handlers even if it is no
+        // longer (or never was) the one on record in adminInventories.
         HandlerList.unregisterAll(this);
+        clearPlayerEditState(ownerId);
+    }
 
-        // 2) Remove from adminInventories
-        adminInventories.remove(ownerId);
+    /**
+     * Removes {@code playerId} from every AdminMenu-owned edit-mode/
+     * occupation map, and unregisters + tears down their AdminMenu
+     * instance if one is currently open. Safe to call even when the
+     * player has no admin inventory open at all — e.g. they left the
+     * settings menu to type a new value in chat and disconnected before
+     * submitting it, which is the scenario that previously left them
+     * permanently locked out (nothing but a successful chat submission or
+     * an open-inventory close ever cleared these maps).
+     */
+    public static void clearPlayerEditState(UUID playerId) {
+        moveMode.remove(playerId);
+        nameEditMode.remove(playerId);
+        timerEditMode.remove(playerId);
+        standOn17Mode.remove(playerId);
+        editMinesMode.remove(playerId);
+        amsgEditMode.remove(playerId);
+        chipEditMode.remove(playerId);
+        currencyEditMode.remove(playerId);
+        decksEditMode.remove(playerId);
+        dragonEditMode.remove(playerId);
+        localMob.remove(playerId);
 
-        // 3) Remove player references from the specialized maps
-        moveMode.remove(ownerId);
-        nameEditMode.remove(ownerId);
-        timerEditMode.remove(ownerId);
-        amsgEditMode.remove(ownerId);
-        chipEditMode.remove(ownerId);
-        localMob.remove(ownerId);
-        currencyEditMode.remove(ownerId);
+        AdminMenu menu = adminInventories.remove(playerId);
+        if (menu != null) {
+            HandlerList.unregisterAll(menu);
+        }
     }
 
     public static void clearAllEditModes(Mob mob) {

--- a/src/main/java/org/nc/nccasino/components/BaccaratMenu.java
+++ b/src/main/java/org/nc/nccasino/components/BaccaratMenu.java
@@ -63,6 +63,14 @@ public class BaccaratMenu extends Menu {
         AdminMenu.decksEditMode.remove(ownerId);
         this.delete();
     }
+
+    /** Tears down this player's open BaccaratMenu, if any. AdminMenu's own edit-mode maps are cleared separately and unconditionally by AdminMenu.clearPlayerEditState. */
+    public static void clearPlayerState(UUID playerId) {
+        BaccaratMenu menu = RAInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        }
+    }
     
     public boolean isPlayerOccupied(UUID playerId){
         return 

--- a/src/main/java/org/nc/nccasino/components/BlackjackMenu.java
+++ b/src/main/java/org/nc/nccasino/components/BlackjackMenu.java
@@ -66,6 +66,14 @@ public class BlackjackMenu extends Menu {
         this.delete();
     }
 
+    /** Tears down this player's open BlackjackMenu, if any. AdminMenu's own edit-mode maps are cleared separately and unconditionally by AdminMenu.clearPlayerEditState, so this only needs to handle the case where a menu instance still exists. */
+    public static void clearPlayerState(UUID playerId) {
+        BlackjackMenu menu = BAInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        }
+    }
+
     @Override
     protected void initializeMenu(){
         String internalName = Dealer.getInternalName(dealer);

--- a/src/main/java/org/nc/nccasino/components/CoinFlipMenu.java
+++ b/src/main/java/org/nc/nccasino/components/CoinFlipMenu.java
@@ -61,6 +61,14 @@ public class CoinFlipMenu extends Menu {
         this.delete();
     }
 
+    /** Tears down this player's open CoinFlipMenu, if any. AdminMenu's own edit-mode maps are cleared separately and unconditionally by AdminMenu.clearPlayerEditState. */
+    public static void clearPlayerState(UUID playerId) {
+        CoinFlipMenu menu = RAInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        }
+    }
+
     @Override
     protected void initializeMenu(){
         String internalName = Dealer.getInternalName(dealer);

--- a/src/main/java/org/nc/nccasino/components/DragonDescentMenu.java
+++ b/src/main/java/org/nc/nccasino/components/DragonDescentMenu.java
@@ -60,6 +60,24 @@ public class DragonDescentMenu extends Menu {
         this.delete();
     }
 
+    /**
+     * Tears down this player's open DragonDescentMenu, if any — that also
+     * clears editDragonSetting and AdminMenu.dragonEditMode via cleanup().
+     * AdminMenu.dragonEditMode is additionally cleared separately and
+     * unconditionally by AdminMenu.clearPlayerEditState, but
+     * editDragonSetting is owned only here, so if no menu instance exists
+     * (e.g. mid chat-wait for a specific setting) it must still be cleared
+     * directly.
+     */
+    public static void clearPlayerState(UUID playerId) {
+        DragonDescentMenu menu = dragonInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        } else {
+            editDragonSetting.remove(playerId);
+        }
+    }
+
     @Override
     protected void initializeMenu() {
         String internalName = Dealer.getInternalName(dealer);

--- a/src/main/java/org/nc/nccasino/components/MinesMenu.java
+++ b/src/main/java/org/nc/nccasino/components/MinesMenu.java
@@ -65,6 +65,14 @@ public class MinesMenu extends Menu {
         this.delete();
     }
 
+    /** Tears down this player's open MinesMenu, if any. AdminMenu's own edit-mode maps are cleared separately and unconditionally by AdminMenu.clearPlayerEditState. */
+    public static void clearPlayerState(UUID playerId) {
+        MinesMenu menu = MAInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        }
+    }
+
     @Override
     protected void initializeMenu(){
         String internalName = Dealer.getInternalName(dealer);

--- a/src/main/java/org/nc/nccasino/components/RouletteMenu.java
+++ b/src/main/java/org/nc/nccasino/components/RouletteMenu.java
@@ -62,6 +62,14 @@ public class RouletteMenu extends Menu {
         this.delete();
     }
 
+    /** Tears down this player's open RouletteMenu, if any. AdminMenu's own edit-mode maps are cleared separately and unconditionally by AdminMenu.clearPlayerEditState. */
+    public static void clearPlayerState(UUID playerId) {
+        RouletteMenu menu = RAInventories.get(playerId);
+        if (menu != null) {
+            menu.cleanup();
+        }
+    }
+
     @Override
     protected void initializeMenu(){
         String internalName = Dealer.getInternalName(dealer);

--- a/src/main/java/org/nc/nccasino/entities/Server.java
+++ b/src/main/java/org/nc/nccasino/entities/Server.java
@@ -127,9 +127,20 @@ public abstract class Server extends DealerInventory {
 
     public Client getOrCreateClient(Player player) {
         UUID uuid = player.getUniqueId();
-        if (clients.containsKey(uuid)) {
-            return clients.get(uuid);
+        Client existing = clients.get(uuid);
+        if (existing != null) {
+            if (isStale(existing, player)) {
+                // A previous session's Client is still registered, holding
+                // a dead Player reference (e.g. cleanup never ran because
+                // they disconnected rather than closing the inventory).
+                // Reusing it would silently fail to message/pay the actual
+                // reconnected player, so discard it before creating fresh.
+                removeClient(uuid);
+            } else {
+                return existing;
+            }
         }
+
         // Create a new client using the abstract factory method
         Client newClient = createClientForPlayer(player);
         clients.put(uuid, newClient);
@@ -138,6 +149,18 @@ public abstract class Server extends DealerInventory {
         clientStates.put(uuid, SessionState.LOBBY);
 
         return newClient;
+    }
+
+    /**
+     * A cached Client is only safe to reuse if it still refers to the
+     * exact Player object of the current login session. UUID equality
+     * alone isn't enough — Bukkit hands out a brand-new Player object on
+     * every reconnect, so an old, disconnected Player reference can share
+     * the same UUID while being otherwise dead.
+     */
+    private boolean isStale(Client existing, Player currentPlayer) {
+        Player cachedPlayer = existing.getPlayer();
+        return cachedPlayer == null || !cachedPlayer.isOnline() || !cachedPlayer.equals(currentPlayer);
     }
 
     protected abstract Client createClientForPlayer(Player player);

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
@@ -25,6 +25,8 @@ import org.nc.nccasino.entities.Server;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.objects.Card;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
+import org.nc.nccasino.session.TerminationAction;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -824,15 +826,17 @@ public class BaccaratClient extends Client implements TerminableSession {
         BaccaratServer baccaratServer = (BaccaratServer) server;
         sendUpdateToServer("INVENTORY_CLOSE", null);
 
-        if (reason == ExitReason.KICKED) {
+        boolean waitingForRound = baccaratServer.getGameState() == Server.GameState.WAITING;
+        TerminationAction action = GameTerminationPolicy.baccarat(reason, waitingForRound);
+        if (action == TerminationAction.FORFEIT) {
             // Forfeit unconditionally regardless of phase — no refund, no
             // pending payout, seat and bet both stripped outright.
             baccaratServer.forfeitPlayer(terminatedPlayerId);
-        } else if (baccaratServer.getGameState() == Server.GameState.WAITING) {
+        } else if (action == TerminationAction.REFUND && waitingForRound) {
             // Pregame: nothing has been risked into an active hand yet,
             // so this is a plain refund.
             sendUpdateToServer("PLAYER_LEFT_BEFORE_START", null);
-        } else if (reason == ExitReason.PLUGIN_DISABLE) {
+        } else if (action == TerminationAction.REFUND) {
             // Mid-hand, but the scheduled deal/draw/evaluate chain that
             // would normally carry this bet to a real outcome is about to
             // be cancelled along with everything else — refund instead of

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
@@ -832,6 +832,13 @@ public class BaccaratClient extends Client implements TerminableSession {
             // Pregame: nothing has been risked into an active hand yet,
             // so this is a plain refund.
             sendUpdateToServer("PLAYER_LEFT_BEFORE_START", null);
+        } else if (reason == ExitReason.PLUGIN_DISABLE) {
+            // Mid-hand, but the scheduled deal/draw/evaluate chain that
+            // would normally carry this bet to a real outcome is about to
+            // be cancelled along with everything else — refund instead of
+            // trying to let it ride through a hand that will never finish.
+            baccaratServer.refundForShutdown(terminatedPlayerId);
+            baccaratServer.releaseSeatForDisconnect(terminatedPlayerId);
         } else {
             // Mid-hand: the bet already rode into the hand and resolves
             // normally by UUID at payout time (delivered as a pending

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratClient.java
@@ -24,8 +24,11 @@ import org.nc.nccasino.entities.Client;
 import org.nc.nccasino.entities.Server;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.objects.Card;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class BaccaratClient extends Client {
+public class BaccaratClient extends Client implements TerminableSession {
     private final int[] playerCardSlots = {10,11,12};  // Left to right
     private final int[] bankerCardSlots = {16,15,14};  // Right to left
     private final List<Card> playerHand = new ArrayList<>();
@@ -37,6 +40,7 @@ public class BaccaratClient extends Client {
     protected final List<BetData> betHistory = new ArrayList<>();
      private final Map<Integer, UUID> seatMap = new HashMap<>();
     private final int[] seatSlots = {37, 38, 39, 40, 41, 42, 43};
+    private boolean sessionResolved = false;
     
     protected enum SlotOption {
         EXIT,
@@ -67,6 +71,7 @@ public class BaccaratClient extends Client {
 
         public BaccaratClient(BaccaratServer server, Player player, Nccasino plugin, String internalName) {
             super(server, player, "Baccarat", plugin, internalName);
+            SessionRegistry.register(player.getUniqueId(), this);
             slotMapping.put(53,SlotOption.EXIT );
             slotMapping.put(52,SlotOption.ALLIN);
             slotMapping.put(51,SlotOption.WAGER1);
@@ -793,13 +798,48 @@ public class BaccaratClient extends Client {
 
     @Override
     public void handleClientInventoryClose() {
-    sendUpdateToServer("INVENTORY_CLOSE", null);
-
-    // Remove player from seat and refund bets if game hasn't started
-    if (((BaccaratServer) server).getGameState() == Server.GameState.WAITING) {
-        sendUpdateToServer("PLAYER_LEFT_BEFORE_START", null);
+        // Route through the same idempotent path used for quit/kick rather
+        // than resolving directly here — whichever of this or the quit
+        // event fires first "wins" and the other becomes a safe no-op, and
+        // consumeQuitReason still correctly reports KICKED here even if
+        // this fires first, since the kick is marked as soon as
+        // PlayerKickEvent itself fires.
+        UUID playerId = player.getUniqueId();
+        ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+        SessionRegistry.terminatePlayerSession(playerId, reason);
     }
-        super.handleClientInventoryClose(); // Calls base logic to remove the client
+
+    /**
+     * Authoritative disconnect/kick resolution, reached via SessionRegistry
+     * regardless of whether this fires from PlayerQuitEvent or from this
+     * client's own InventoryCloseEvent.
+     */
+    @Override
+    public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
+        if (sessionResolved) {
+            return; // already resolved through another path
+        }
+        sessionResolved = true;
+
+        BaccaratServer baccaratServer = (BaccaratServer) server;
+        sendUpdateToServer("INVENTORY_CLOSE", null);
+
+        if (reason == ExitReason.KICKED) {
+            // Forfeit unconditionally regardless of phase — no refund, no
+            // pending payout, seat and bet both stripped outright.
+            baccaratServer.forfeitPlayer(terminatedPlayerId);
+        } else if (baccaratServer.getGameState() == Server.GameState.WAITING) {
+            // Pregame: nothing has been risked into an active hand yet,
+            // so this is a plain refund.
+            sendUpdateToServer("PLAYER_LEFT_BEFORE_START", null);
+        } else {
+            // Mid-hand: the bet already rode into the hand and resolves
+            // normally by UUID at payout time (delivered as a pending
+            // payout if still offline then) — just free the seat.
+            baccaratServer.releaseSeatForDisconnect(terminatedPlayerId);
+        }
+
+        server.removeClient(terminatedPlayerId);
     }
 
     public void saveCurrentBets() {

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
@@ -777,6 +777,10 @@ public class BaccaratServer extends Server {
      * timing window as resolving directly inside a quit/close handler.
      */
     private void queuePendingPayout(UUID playerId, double amount) {
+    	queuePendingPayout(playerId, amount, PayoutMessages.disconnectedMidGameContext("Baccarat"));
+    }
+
+    private void queuePendingPayout(UUID playerId, double amount, String context) {
     	Material currencyMaterial = plugin.getCurrency(internalName);
     	PendingPayout pendingPayout = PendingPayout.create(
     		playerId,
@@ -786,11 +790,40 @@ public class BaccaratServer extends Server {
     		currencyMaterial != null ? currencyMaterial.name() : null,
     		currencyName,
     		amount,
-    		PayoutMessages.disconnectedMidGameContext("Baccarat")
+    		context
     	);
     	boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(pendingPayout);
     	if (!persisted) {
     		plugin.getLogger().warning("[NCCasino] Baccarat pending payout failed to persist for " + playerId + ".");
+    	}
+    }
+
+    /**
+     * The server is shutting down with this player's bet still committed
+     * to an in-flight hand. The scheduled deal/draw/evaluate chain that
+     * would normally carry it to a real outcome is about to be cancelled
+     * along with everything else, so refund the wager via the durable
+     * pending-payout store instead.
+     */
+    void refundForShutdown(UUID playerId) {
+    	Map<BaccaratClient.BetOption, Double> bets = playerBets.remove(playerId);
+    	if (bets == null || bets.isEmpty()) {
+    		return;
+    	}
+
+    	double total = bets.values().stream().mapToDouble(Double::doubleValue).sum();
+    	for (Map.Entry<BaccaratClient.BetOption, Double> entry : bets.entrySet()) {
+    		double amount = entry.getValue();
+    		totalBets.computeIfPresent(entry.getKey(), (k, v) -> (v - amount) <= 0 ? null : v - amount);
+    	}
+    	for (BaccaratClient.BetOption betType : BaccaratClient.BetOption.values()) {
+    		broadcastUpdate("UPDATE_BET_DISPLAY", new BetDisplayData(
+    			betType, 0.0, totalBets.getOrDefault(betType, 0.0)
+    		));
+    	}
+
+    	if (total > 0) {
+    		queuePendingPayout(playerId, total, PayoutMessages.serverRestartRefundContext("Baccarat"));
     	}
     }
 

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
@@ -584,7 +584,7 @@ public class BaccaratServer extends Server {
         if (bankerDraws) {
                 drawBankerCard();
         } else {
-            Bukkit.getScheduler().runTaskLater(plugin, this::determineWinner, 40L);
+            determineWinner();
         }
     }
     
@@ -594,7 +594,7 @@ public class BaccaratServer extends Server {
             bankerHand.add(deck.dealCard());
             broadcastUpdate("BANKER_DRAW", bankerHand.get(bankerHand.size() - 1));
             updateHandTotals();
-            Bukkit.getScheduler().runTaskLater(plugin, this::determineWinner, 40L);
+            determineWinner();
         }, 20L);
     }
     

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
@@ -9,6 +9,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
@@ -23,6 +24,8 @@ import org.nc.nccasino.entities.Server;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.objects.Card;
 import org.nc.nccasino.objects.Deck;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
 
 public class BaccaratServer extends Server {
     private final Map<BaccaratClient.BetOption, Double> totalBets = new HashMap<>();
@@ -284,6 +287,43 @@ public class BaccaratServer extends Server {
             player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_WORK_CARTOGRAPHER, SoundCategory.MASTER, 1.0f, 1.0f);
         }
         undoAllBets(player);
+        sendSeatUpdates();
+    }
+
+    /**
+     * Kicked players forfeit unconditionally, regardless of round phase —
+     * no refund, no pending payout. Also strips their contribution out of
+     * the shared totalBets display so it doesn't overstate what's actually
+     * still in play.
+     */
+    void forfeitPlayer(UUID playerId) {
+        seatedPlayers.remove(playerId);
+        seatMap.values().removeIf(id -> id.equals(playerId));
+
+        Map<BaccaratClient.BetOption, Double> bets = playerBets.remove(playerId);
+        if (bets != null) {
+            for (Map.Entry<BaccaratClient.BetOption, Double> entry : bets.entrySet()) {
+                double amount = entry.getValue();
+                totalBets.computeIfPresent(entry.getKey(), (k, v) -> (v - amount) <= 0 ? null : v - amount);
+            }
+            for (BaccaratClient.BetOption betType : BaccaratClient.BetOption.values()) {
+                broadcastUpdate("UPDATE_BET_DISPLAY", new BetDisplayData(
+                    betType, 0.0, totalBets.getOrDefault(betType, 0.0)
+                ));
+            }
+        }
+        sendSeatUpdates();
+    }
+
+    /**
+     * A mid-hand disconnect (not a kick) frees the seat immediately for
+     * someone else, but deliberately leaves playerBets untouched — that
+     * bet still rides the hand to a real outcome in processPayouts,
+     * resolved by UUID regardless of whether they're back online by then.
+     */
+    void releaseSeatForDisconnect(UUID playerId) {
+        seatedPlayers.remove(playerId);
+        seatMap.values().removeIf(id -> id.equals(playerId));
         sendSeatUpdates();
     }
 
@@ -622,7 +662,7 @@ public class BaccaratServer extends Server {
     private void processPayouts(String result) {
     	for (UUID playerId : playerBets.keySet()) {
     		Player player = Bukkit.getPlayer(playerId);
-    		if (player == null) continue;
+    		boolean online = player != null && player.isOnline();
 
     		double payout = 0.0;
     		double totalBet = 0.0;
@@ -661,61 +701,97 @@ public class BaccaratServer extends Server {
 				java.math.BigDecimal displayPayout = MoneyHelper.roundDisplay(payoutBD);
 				java.math.BigDecimal displayProfit = MoneyHelper.roundDisplay(payoutBD.subtract(betAmount));
 
-				if (payoutBD.compareTo(java.math.BigDecimal.ZERO) > 0) {
-					((VaultCurrencyProvider) provider).deposit(player, internalName, payoutBD);
-				}
+				if (online) {
+					if (payoutBD.compareTo(java.math.BigDecimal.ZERO) > 0) {
+						((VaultCurrencyProvider) provider).deposit(player, internalName, payoutBD);
+					}
 
-	    		switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-	    			case STANDARD:{
-	    				player.sendMessage("§a§lPaid " + plugin.formatWagerDisplay(currencyMode, currencyName, displayPayout.doubleValue()));
-	    				break;}
-	    			case VERBOSE:{
-	    				player.sendMessage("§a§lPaid " + plugin.formatWagerDisplay(currencyMode, currencyName, displayPayout.doubleValue()) + "\n §r§a§o(profit of " + plugin.formatWagerDisplay(currencyMode, currencyName, displayProfit.doubleValue()) + ")");
-	    				break;     
-	    			}
-	    				case NONE:{
-	    				break;
-	    			}
-	    		}
+		    		switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
+		    			case STANDARD:{
+		    				player.sendMessage("§a§lPaid " + plugin.formatWagerDisplay(currencyMode, currencyName, displayPayout.doubleValue()));
+		    				break;}
+		    			case VERBOSE:{
+		    				player.sendMessage("§a§lPaid " + plugin.formatWagerDisplay(currencyMode, currencyName, displayPayout.doubleValue()) + "\n §r§a§o(profit of " + plugin.formatWagerDisplay(currencyMode, currencyName, displayProfit.doubleValue()) + ")");
+		    				break;
+		    			}
+		    				case NONE:{
+		    				break;
+		    			}
+		    		}
+				} else if (payoutBD.compareTo(java.math.BigDecimal.ZERO) > 0) {
+					queuePendingPayout(playerId, payoutBD.doubleValue());
+				}
 			} else {
 	    		// Apply probabilistic rounding only for discrete (item-based) currencies
 	    		payout = applyProbabilisticRoundingIfDiscrete(payout);
 
-	    		if (payout > 0) {
-	    			creditPlayer(player, payout);
-	    		}
-	    		switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-	    			case STANDARD:{
-	    				player.sendMessage("§a§lPaid "+ plugin.formatWagerDisplay(currencyMode, currencyName, payout));
-	    				break;}
-	    			case VERBOSE:{
-	    				player.sendMessage("§a§lPaid "+ plugin.formatWagerDisplay(currencyMode, currencyName, payout) + "\n §r§a§o(profit of "+(int)(payout-totalBet)+")");
-	    				break;     
-	    			}
-	    				case NONE:{
-	    				break;
-	    			}
-	    		} 
+				if (online) {
+		    		if (payout > 0) {
+		    			creditPlayer(player, payout);
+		    		}
+		    		switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
+		    			case STANDARD:{
+		    				player.sendMessage("§a§lPaid "+ plugin.formatWagerDisplay(currencyMode, currencyName, payout));
+		    				break;}
+		    			case VERBOSE:{
+		    				player.sendMessage("§a§lPaid "+ plugin.formatWagerDisplay(currencyMode, currencyName, payout) + "\n §r§a§o(profit of "+(int)(payout-totalBet)+")");
+		    				break;
+		    			}
+		    				case NONE:{
+		    				break;
+		    			}
+		    		}
+				} else if (payout > 0) {
+					queuePendingPayout(playerId, payout);
+				}
 			}
-    		if (payout > totalBet) {
-    			player.getWorld().spawnParticle(Particle.GLOW, player.getLocation(), 50);
-    			Random random = new Random();
-    			float[] possiblePitches = {0.5f, 0.8f, 1.2f, 1.5f, 1.8f,0.7f, 0.9f, 1.1f, 1.4f, 1.9f};
-    			for (int i = 0; i < 3; i++) {
-    				float chosenPitch = possiblePitches[random.nextInt(possiblePitches.length)];
-    				 if (SoundHelper.getSoundSafely("entity.player.levelup", player) != null)player.playSound(player.getLocation(),Sound.ENTITY_PLAYER_LEVELUP, SoundCategory.MASTER,1.0f,chosenPitch);
-    			}
-    		} else if (payout == totalBet) {
-    			if (SoundHelper.getSoundSafely("item.shield.break", player) != null)player.playSound(player.getLocation(), Sound.ITEM_SHIELD_BREAK,SoundCategory.MASTER,1.0f, 1.0f);
-    			player.getWorld().spawnParticle(Particle.SCRAPE, player.getLocation(), 20); 
-    		} else {
-    			if (SoundHelper.getSoundSafely("entity.generic.explode", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE,SoundCategory.MASTER,1.0f, 1.0f);
-    			player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20);  
+
+    		if (online) {
+	    		if (payout > totalBet) {
+	    			player.getWorld().spawnParticle(Particle.GLOW, player.getLocation(), 50);
+	    			Random random = new Random();
+	    			float[] possiblePitches = {0.5f, 0.8f, 1.2f, 1.5f, 1.8f,0.7f, 0.9f, 1.1f, 1.4f, 1.9f};
+	    			for (int i = 0; i < 3; i++) {
+	    				float chosenPitch = possiblePitches[random.nextInt(possiblePitches.length)];
+	    				 if (SoundHelper.getSoundSafely("entity.player.levelup", player) != null)player.playSound(player.getLocation(),Sound.ENTITY_PLAYER_LEVELUP, SoundCategory.MASTER,1.0f,chosenPitch);
+	    			}
+	    		} else if (payout == totalBet) {
+	    			if (SoundHelper.getSoundSafely("item.shield.break", player) != null)player.playSound(player.getLocation(), Sound.ITEM_SHIELD_BREAK,SoundCategory.MASTER,1.0f, 1.0f);
+	    			player.getWorld().spawnParticle(Particle.SCRAPE, player.getLocation(), 20);
+	    		} else {
+	    			if (SoundHelper.getSoundSafely("entity.generic.explode", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE,SoundCategory.MASTER,1.0f, 1.0f);
+	    			player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20);
+	    		}
     		}
 
     	}
 
     	resetGame();
+    }
+
+    /**
+     * Queues a won bet as a durable pending payout when the player is
+     * offline at the exact moment the hand resolves. This runs well after
+     * any disconnect (through the deal/draw/evaluate task chain), so
+     * checking online status here is reliable — not the same uncertain
+     * timing window as resolving directly inside a quit/close handler.
+     */
+    private void queuePendingPayout(UUID playerId, double amount) {
+    	Material currencyMaterial = plugin.getCurrency(internalName);
+    	PendingPayout pendingPayout = PendingPayout.create(
+    		playerId,
+    		"Baccarat",
+    		internalName,
+    		currencyMode,
+    		currencyMaterial != null ? currencyMaterial.name() : null,
+    		currencyName,
+    		amount,
+    		PayoutMessages.disconnectedMidGameContext("Baccarat")
+    	);
+    	boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(pendingPayout);
+    	if (!persisted) {
+    		plugin.getLogger().warning("[NCCasino] Baccarat pending payout failed to persist for " + playerId + ".");
+    	}
     }
 
     /**

--- a/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
+++ b/src/main/java/org/nc/nccasino/games/Baccarat/BaccaratServer.java
@@ -647,7 +647,16 @@ public class BaccaratServer extends Server {
         broadcastUpdate("RESULT", result);
         currentWinString=result;
         processPayouts(result);
-    
+
+        // Clear bets synchronously now that they're paid, rather than
+        // waiting for resetGame()'s 70-tick visual-reset delay — otherwise
+        // a shutdown landing in that window still sees a payable-looking
+        // bet for a hand that was already paid, and refundForShutdown
+        // would queue a second payout on top of what processPayouts just
+        // gave everyone.
+        playerBets.clear();
+        totalBets.clear();
+
         // Save the current bets before the game resets
         for (Client client : clients.values()) {
             if (client instanceof BaccaratClient &&client.rebetEnabled) {

--- a/src/main/java/org/nc/nccasino/games/Blackjack/BlackjackInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Blackjack/BlackjackInventory.java
@@ -40,8 +40,11 @@ import org.nc.nccasino.objects.Card;
 import org.nc.nccasino.objects.Deck;
 import org.nc.nccasino.objects.Suit;
 import org.nc.nccasino.helpers.SoundHelper;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class BlackjackInventory extends DealerInventory {
+public class BlackjackInventory extends DealerInventory implements TerminableSession {
 
     private final Nccasino plugin; // Reference to the main plugin
     private final Map<String, Double> chipValues; // Track chip values
@@ -839,6 +842,7 @@ private void handleInsurance(Player player) {
         }
         // Track the player's seat
         playerSeats.put(playerId, slot);
+        SessionRegistry.register(playerId, this);
     }
     
 
@@ -930,6 +934,7 @@ private void removePlayerData(UUID playerId) {
 
         // Remove player from seat map
         playerSeats.remove(playerId);
+        SessionRegistry.unregister(playerId, this);
 
         // Ensure player is removed from active turns
         if (playerIterator != null) {
@@ -2262,18 +2267,85 @@ public void delete() {
         @EventHandler
         public void handleInventoryClose(InventoryCloseEvent event) {
             if (event.getInventory().getHolder() != this) return;
-        
+
             Player player = (Player) event.getPlayer();
+            UUID playerId = player.getUniqueId();
 
-        
-            if (!gameActive) {
-                handleUndoAllBets(player);
-                handleLeaveChair(player);
-            } else {
-                handleLeaveChairDuringGame(player);
+            if (!playerSeats.containsKey(playerId)) {
+                return;
             }
-        }
-        
 
-    
+            // Route through the same idempotent path used for quit/kick,
+            // rather than resolving the wager directly here. It's unclear
+            // whether InventoryCloseEvent reliably fires on a real
+            // disconnect, so this must not race ahead of PlayerQuitEvent
+            // and get it wrong (e.g. refunding a kicked player) — whichever
+            // of this or the quit event fires first "wins" and the other
+            // becomes a safe no-op, and consumeQuitReason still correctly
+            // reports KICKED here even if this fires first, since the kick
+            // is marked as soon as PlayerKickEvent itself fires.
+            ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+            SessionRegistry.terminatePlayerSession(playerId, reason);
+        }
+
+    /**
+     * Authoritative disconnect/kick resolution, reached via SessionRegistry
+     * regardless of whether this fires from PlayerQuitEvent or from this
+     * table's own InventoryCloseEvent. Transition is based on {@code
+     * gameActive} — set the instant dealing is committed server-side, not
+     * on any animation — never on what the client had visibly rendered.
+     */
+    @Override
+    public void onSessionTerminated(UUID playerId, ExitReason reason) {
+        if (!playerSeats.containsKey(playerId)) {
+            // Already resolved through another path (e.g. a voluntary
+            // leave-chair click that ran before this).
+            return;
+        }
+
+        if (gameActive) {
+            // Deal has begun: forfeit unconditionally. Never calculate an
+            // automated hand or create a pending payout. Advance the turn
+            // safely first if it was theirs.
+            if (playerId.equals(currentPlayerId)) {
+                playerDone.put(playerId, true);
+                startNextPlayerTurn();
+            }
+            removePlayerData(playerId);
+        } else {
+            // Before the deal: refund the committed wager, unless kicked —
+            // a kicked player forfeits regardless of phase.
+            if (reason != ExitReason.KICKED) {
+                refundPendingBets(playerId);
+            }
+            removePlayerData(playerId);
+        }
+
+        if (playerSeats.isEmpty()) {
+            sittable = false;
+        }
+    }
+
+    /**
+     * Refunds whatever {@code playerId} currently has wagered. Called
+     * before removePlayerData, which clears the underlying bet records
+     * without moving any currency itself.
+     */
+    private void refundPendingBets(UUID playerId) {
+        Map<Integer, Double> bets = playerBets.get(playerId);
+        if (bets == null || bets.isEmpty()) {
+            return;
+        }
+
+        double total = bets.values().stream().mapToDouble(Double::doubleValue).sum();
+        if (total <= 0) {
+            return;
+        }
+
+        Player player = Bukkit.getPlayer(playerId);
+        if (player != null) {
+            addWagerToInventory(player, total);
+        }
+    }
+
 }

--- a/src/main/java/org/nc/nccasino/games/Blackjack/BlackjackInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Blackjack/BlackjackInventory.java
@@ -40,7 +40,10 @@ import org.nc.nccasino.objects.Card;
 import org.nc.nccasino.objects.Deck;
 import org.nc.nccasino.objects.Suit;
 import org.nc.nccasino.helpers.SoundHelper;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -2303,7 +2306,9 @@ public void delete() {
             return;
         }
 
-        if (gameActive) {
+        org.nc.nccasino.session.TerminationAction action =
+            GameTerminationPolicy.blackjack(reason, gameActive);
+        if (action == org.nc.nccasino.session.TerminationAction.FORFEIT) {
             // Deal has begun: forfeit unconditionally. Never calculate an
             // automated hand or create a pending payout. Advance the turn
             // safely first if it was theirs.
@@ -2312,12 +2317,12 @@ public void delete() {
                 startNextPlayerTurn();
             }
             removePlayerData(playerId);
-        } else {
+        } else if (action == org.nc.nccasino.session.TerminationAction.REFUND) {
             // Before the deal: refund the committed wager, unless kicked —
             // a kicked player forfeits regardless of phase.
-            if (reason != ExitReason.KICKED) {
-                refundPendingBets(playerId);
-            }
+            refundPendingBets(playerId, reason);
+            removePlayerData(playerId);
+        } else {
             removePlayerData(playerId);
         }
 
@@ -2331,7 +2336,7 @@ public void delete() {
      * before removePlayerData, which clears the underlying bet records
      * without moving any currency itself.
      */
-    private void refundPendingBets(UUID playerId) {
+    private void refundPendingBets(UUID playerId, ExitReason reason) {
         Map<Integer, Double> bets = playerBets.get(playerId);
         if (bets == null || bets.isEmpty()) {
             return;
@@ -2342,9 +2347,26 @@ public void delete() {
             return;
         }
 
-        Player player = Bukkit.getPlayer(playerId);
-        if (player != null) {
-            addWagerToInventory(player, total);
+        if (reason == ExitReason.PLUGIN_DISABLE) {
+            Material currencyMaterial = plugin.getCurrency(internalName);
+            PendingPayout payout = PendingPayout.create(
+                playerId,
+                "Blackjack",
+                internalName,
+                currencyMode,
+                currencyMaterial != null ? currencyMaterial.name() : null,
+                currencyName,
+                total,
+                PayoutMessages.serverRestartRefundContext("Blackjack")
+            );
+            if (!plugin.getPendingPayoutStore().addPendingPayout(payout)) {
+                plugin.getLogger().warning("[NCCasino] Blackjack shutdown refund failed to persist for " + playerId + ".");
+            }
+        } else {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                addWagerToInventory(player, total);
+            }
         }
     }
 

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
@@ -125,6 +125,14 @@ public class CoinFlipClient extends Client implements TerminableSession {
             // forfeit unconditionally, no refund.
             server.removeClient(terminatedPlayerId);
             ((CoinFlipServer) server).forfeitPlayer(terminatedPlayerId);
+        } else if (gameActive && reason == ExitReason.PLUGIN_DISABLE) {
+            // The flip is already accepted and in-flight, but the
+            // scheduled resolution (both the animation callback and the
+            // server's own fallback timer) is about to be cancelled along
+            // with everything else — refund both sides' stakes instead of
+            // trying to let it ride to a result that will never come.
+            ((CoinFlipServer) server).refundForShutdown();
+            server.removeClient(terminatedPlayerId);
         } else {
             if (!gameActive) {
                 if (player == chairOneOccupant) {

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
@@ -2,6 +2,7 @@ package org.nc.nccasino.games.CoinFlip;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -15,8 +16,11 @@ import org.nc.nccasino.Nccasino;
 import org.nc.nccasino.entities.Client;
 import org.nc.nccasino.entities.Server;
 import org.nc.nccasino.helpers.SoundHelper;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class CoinFlipClient extends Client {
+public class CoinFlipClient extends Client implements TerminableSession {
 
     private enum SlotOption
     {
@@ -35,9 +39,11 @@ public class CoinFlipClient extends Client {
     private final String clickHereToSit = "§f§oClick here to sit";
     private boolean gameActive = false;
     private boolean betAccepted = false;
+    private boolean sessionResolved = false;
 
     public CoinFlipClient(Server server, Player player, Nccasino plugin, String internalName) {
         super(server, player, "Coin Flip", plugin, internalName);
+        SessionRegistry.register(player.getUniqueId(), this);
         this.chairOneOccupant = null;
         this.chairTwoOccupant = null;
 
@@ -89,15 +95,51 @@ public class CoinFlipClient extends Client {
     
     @Override
     protected void handleClientInventoryClose() {
-        if(!gameActive){
-            if(player == chairOneOccupant){
-                sendUpdateToServer("PLAYER_LEAVE_ONE", null);
-            }
-            if(player == chairTwoOccupant){
-                sendUpdateToServer("PLAYER_LEAVE_TWO", null);
-            }
+        // Route through the same idempotent path used for quit/kick rather
+        // than resolving directly here — whichever of this or the quit
+        // event fires first "wins" and the other becomes a safe no-op, and
+        // consumeQuitReason still correctly reports KICKED here even if
+        // this fires first, since the kick is marked as soon as
+        // PlayerKickEvent itself fires.
+        UUID playerId = player.getUniqueId();
+        ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+        SessionRegistry.terminatePlayerSession(playerId, reason);
+    }
+
+    /**
+     * Authoritative disconnect/kick resolution, reached via SessionRegistry
+     * regardless of whether this fires from PlayerQuitEvent or from this
+     * client's own InventoryCloseEvent.
+     */
+    @Override
+    public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
+        if (sessionResolved) {
+            return; // already resolved through another path
         }
-        super.handleClientInventoryClose();
+        sessionResolved = true;
+
+        if (reason == ExitReason.KICKED) {
+            // Remove from the server's client registry first so this
+            // client can't receive (and self-refund against) the
+            // seat-leave broadcast forfeitPlayer causes — kicked players
+            // forfeit unconditionally, no refund.
+            server.removeClient(terminatedPlayerId);
+            ((CoinFlipServer) server).forfeitPlayer(terminatedPlayerId);
+        } else {
+            if (!gameActive) {
+                if (player == chairOneOccupant) {
+                    sendUpdateToServer("PLAYER_LEAVE_ONE", null);
+                }
+                if (player == chairTwoOccupant) {
+                    sendUpdateToServer("PLAYER_LEAVE_TWO", null);
+                }
+            }
+            // gameActive: let it ride — the bet already rode into the
+            // round and resolves normally by UUID at payout time
+            // (delivered as a pending payout if still offline then).
+            // resolveRound's own post-payout cleanup frees the seat.
+            server.removeClient(terminatedPlayerId);
+        }
     }
     
     private void handleChairOne(){

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipClient.java
@@ -17,6 +17,8 @@ import org.nc.nccasino.entities.Client;
 import org.nc.nccasino.entities.Server;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
+import org.nc.nccasino.session.TerminationAction;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -118,14 +120,15 @@ public class CoinFlipClient extends Client implements TerminableSession {
         }
         sessionResolved = true;
 
-        if (reason == ExitReason.KICKED) {
+        TerminationAction action = GameTerminationPolicy.coinFlip(reason, gameActive);
+        if (action == TerminationAction.FORFEIT) {
             // Remove from the server's client registry first so this
             // client can't receive (and self-refund against) the
             // seat-leave broadcast forfeitPlayer causes — kicked players
             // forfeit unconditionally, no refund.
             server.removeClient(terminatedPlayerId);
             ((CoinFlipServer) server).forfeitPlayer(terminatedPlayerId);
-        } else if (gameActive && reason == ExitReason.PLUGIN_DISABLE) {
+        } else if (action == TerminationAction.REFUND && gameActive) {
             // The flip is already accepted and in-flight, but the
             // scheduled resolution (both the animation callback and the
             // server's own fallback timer) is about to be cancelled along
@@ -134,7 +137,7 @@ public class CoinFlipClient extends Client implements TerminableSession {
             ((CoinFlipServer) server).refundForShutdown();
             server.removeClient(terminatedPlayerId);
         } else {
-            if (!gameActive) {
+            if (action == TerminationAction.REFUND && !gameActive) {
                 if (player == chairOneOccupant) {
                     sendUpdateToServer("PLAYER_LEAVE_ONE", null);
                 }

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
@@ -23,6 +23,7 @@ public class CoinFlipServer extends Server {
     protected Player chairTwoOccupant;
     protected int betAmount;
     protected Boolean gameActive;
+    private Integer committedWinner;
     private final Set<UUID> forfeited = new HashSet<>();
 
     public CoinFlipServer(UUID dealerId, Nccasino plugin, String internalName) {
@@ -97,7 +98,7 @@ public class CoinFlipServer extends Server {
                 break;
             case "ANIMATION_FINISHED":
                 if (data instanceof Integer w) {
-                    resolveRound(w);
+                    resolveRound(committedWinner != null ? committedWinner : w);
                 }
                 break;
             case "GET_CHAIRS":
@@ -131,6 +132,7 @@ public class CoinFlipServer extends Server {
         Player payoutTwo = chairTwoOccupant;
         int payout = betAmount;
         gameActive = false;
+        committedWinner = null;
         betAmount = 0;
         timeLeft = 0;
         countdownTaskId = -1;
@@ -211,28 +213,43 @@ public class CoinFlipServer extends Server {
     }
 
     /**
-     * The server is shutting down with a flip already accepted and
-     * in-flight. The scheduled resolution (both the client-driven
-     * animation callback and the server's own fallback timer) is about to
-     * be cancelled along with everything else, so there's no way to let it
-     * ride to a real outcome — refund each side's own stake instead.
+     * Settles an accepted flip during shutdown. Once a winner has been
+     * selected, that authoritative payout is saved; before selection,
+     * each side's stake is refunded.
      */
     void refundForShutdown() {
         if (!gameActive) {
             return;
         }
 
-        int stake = betAmount / 2;
+        int payout = betAmount;
+        int stake = payout / 2;
+        Integer winner = committedWinner;
+        Player payoutOne = chairOneOccupant;
+        Player payoutTwo = chairTwoOccupant;
         gameActive = false;
+        committedWinner = null;
         betAmount = 0;
         timeLeft = 0;
         countdownTaskId = -1;
 
-        if (chairOneOccupant != null && stake > 0) {
-            queuePendingPayout(chairOneOccupant.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
-        }
-        if (chairTwoOccupant != null && stake > 0) {
-            queuePendingPayout(chairTwoOccupant.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
+        if (winner != null) {
+            Player winningPlayer = winner == 0 ? payoutOne : payoutTwo;
+            if (winningPlayer != null && payout > 0
+                && !forfeited.contains(winningPlayer.getUniqueId())) {
+                queuePendingPayout(
+                    winningPlayer.getUniqueId(),
+                    payout,
+                    "The server restarted after your Coin Flip result was determined. Your payout was saved."
+                );
+            }
+        } else {
+            if (payoutOne != null && stake > 0) {
+                queuePendingPayout(payoutOne.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
+            }
+            if (payoutTwo != null && stake > 0) {
+                queuePendingPayout(payoutTwo.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
+            }
         }
         forfeited.clear();
     }
@@ -282,13 +299,9 @@ public class CoinFlipServer extends Server {
             if (timeLeft <= 0) {
                 Bukkit.getScheduler().cancelTask(countdownTaskId);
                 countdownTaskId = -1;
-                if (clients.isEmpty()) {
-                    Bukkit.broadcastMessage("No viewers and no bets - pausing game.");
-                    return;
-                }
-
                 // Otherwise, start the game
                 int winner = Math.random() < 0.5 ? 0 : 1;
+                committedWinner = winner;
                 broadcastUpdate("WINNER", winner);
                 // Resolve authoritatively on a fixed server-side delay
                 // rather than relying solely on a client to report its

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
@@ -189,6 +189,10 @@ public class CoinFlipServer extends Server {
     }
 
     private void queuePendingPayout(UUID playerId, double amount) {
+        queuePendingPayout(playerId, amount, PayoutMessages.disconnectedMidGameContext("Coin Flip"));
+    }
+
+    private void queuePendingPayout(UUID playerId, double amount, String context) {
         Material currencyMaterial = plugin.getCurrency(internalName);
         PendingPayout pendingPayout = PendingPayout.create(
             playerId,
@@ -198,12 +202,39 @@ public class CoinFlipServer extends Server {
             currencyMaterial != null ? currencyMaterial.name() : null,
             currencyName,
             amount,
-            PayoutMessages.disconnectedMidGameContext("Coin Flip")
+            context
         );
         boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(pendingPayout);
         if (!persisted) {
             plugin.getLogger().warning("[NCCasino] Coin Flip pending payout failed to persist for " + playerId + ".");
         }
+    }
+
+    /**
+     * The server is shutting down with a flip already accepted and
+     * in-flight. The scheduled resolution (both the client-driven
+     * animation callback and the server's own fallback timer) is about to
+     * be cancelled along with everything else, so there's no way to let it
+     * ride to a real outcome — refund each side's own stake instead.
+     */
+    void refundForShutdown() {
+        if (!gameActive) {
+            return;
+        }
+
+        int stake = betAmount / 2;
+        gameActive = false;
+        betAmount = 0;
+        timeLeft = 0;
+        countdownTaskId = -1;
+
+        if (chairOneOccupant != null && stake > 0) {
+            queuePendingPayout(chairOneOccupant.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
+        }
+        if (chairTwoOccupant != null && stake > 0) {
+            queuePendingPayout(chairTwoOccupant.getUniqueId(), stake, PayoutMessages.serverRestartRefundContext("Coin Flip"));
+        }
+        forfeited.clear();
     }
 
     /**

--- a/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
+++ b/src/main/java/org/nc/nccasino/games/CoinFlip/CoinFlipServer.java
@@ -1,24 +1,30 @@
 package org.nc.nccasino.games.CoinFlip;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.nc.nccasino.Nccasino;
 import org.nc.nccasino.entities.Client;
 import org.nc.nccasino.entities.Server;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
 
 public class CoinFlipServer extends Server {
 
 
     private int countdownTaskId = -1;
     private int timeLeft = 0;
-    
+
     protected Player chairOneOccupant;
     protected Player chairTwoOccupant;
     protected int betAmount;
     protected Boolean gameActive;
-    
+    private final Set<UUID> forfeited = new HashSet<>();
+
     public CoinFlipServer(UUID dealerId, Nccasino plugin, String internalName) {
         super(dealerId, plugin, internalName);
             
@@ -90,35 +96,8 @@ public class CoinFlipServer extends Server {
                 }
                 break;
             case "ANIMATION_FINISHED":
-                if(gameActive){
-                    broadcastUpdate("ANIMATION_FINISHED", data);
-                    Player payoutOne = chairOneOccupant;
-                    Player payoutTwo = chairTwoOccupant;
-                    int payout = betAmount;
-                    gameActive = false;
-                    betAmount = 0; 
-                    timeLeft = 0;
-                    countdownTaskId = -1;
-                    handlePayout(payoutOne, payoutTwo, payout, (int) data);
-                    if(chairOneOccupant !=null && !hasClient(chairOneOccupant.getUniqueId())){
-                        if(chairTwoOccupant != null){
-                            chairOneOccupant = chairTwoOccupant;
-                            chairTwoOccupant = null;
-                            betAmount = 0;
-                            broadcastUpdate("PLAYER_LEAVE_TWO", null);
-                            broadcastUpdate("PLAYER_LEAVE_ONE", null);
-                            broadcastUpdate("PLAYER_SIT_ONE", chairOneOccupant);
-                        } else {
-                            chairOneOccupant = null;
-                            betAmount = 0;
-                            broadcastUpdate("PLAYER_LEAVE_ONE", null);
-                        }
-                    }
-                    if(chairTwoOccupant !=null && !hasClient(chairTwoOccupant.getUniqueId())){
-                        chairTwoOccupant = null;
-                        broadcastUpdate("PLAYER_LEAVE_TWO", null);
-                    }
-                    
+                if (data instanceof Integer w) {
+                    resolveRound(w);
                 }
                 break;
             case "GET_CHAIRS":
@@ -134,31 +113,140 @@ public class CoinFlipServer extends Server {
         }
     }
 
-    private void handlePayout(Player one, Player two, int payout, int winner) {
-        Player winnerPlayer = (winner == 0) ? one : two;
-        Player loserPlayer = (winner == 0) ? two : one;
-    
-        // Handle payout and messages for the winner
-        if (winnerPlayer != null && payout > 0) {
-            creditPlayer(winnerPlayer, payout);
-            sendPayoutMessage(winnerPlayer, payout, true, payout/2);
-            applyWinEffects(winnerPlayer);
+    /**
+     * Authoritative resolution for a round, called either by whichever
+     * seated client's local flip animation reports back first, or by the
+     * server's own fixed-delay fallback timer scheduled alongside the
+     * WINNER broadcast — whichever fires first wins, the other becomes a
+     * safe no-op via the gameActive guard. This no longer depends on any
+     * client actually being present to report an animation as finished:
+     * previously, if both seated players disconnected before either one's
+     * client-side animation completed, the payout would never run at all.
+     */
+    private void resolveRound(int winner) {
+        if (!gameActive) return;
+
+        broadcastUpdate("ANIMATION_FINISHED", winner);
+        Player payoutOne = chairOneOccupant;
+        Player payoutTwo = chairTwoOccupant;
+        int payout = betAmount;
+        gameActive = false;
+        betAmount = 0;
+        timeLeft = 0;
+        countdownTaskId = -1;
+        handlePayout(payoutOne, payoutTwo, payout, winner);
+        forfeited.clear();
+        if(chairOneOccupant !=null && !hasClient(chairOneOccupant.getUniqueId())){
+            if(chairTwoOccupant != null){
+                chairOneOccupant = chairTwoOccupant;
+                chairTwoOccupant = null;
+                betAmount = 0;
+                broadcastUpdate("PLAYER_LEAVE_TWO", null);
+                broadcastUpdate("PLAYER_LEAVE_ONE", null);
+                broadcastUpdate("PLAYER_SIT_ONE", chairOneOccupant);
+            } else {
+                chairOneOccupant = null;
+                betAmount = 0;
+                broadcastUpdate("PLAYER_LEAVE_ONE", null);
+            }
         }
-    
-        // Handle losing message and effects for the loser
-        if (loserPlayer != null) {
-            sendPayoutMessage(loserPlayer, payout, false, payout/2);
-            applyLoseEffects(loserPlayer);
+        if(chairTwoOccupant !=null && !hasClient(chairTwoOccupant.getUniqueId())){
+            chairTwoOccupant = null;
+            broadcastUpdate("PLAYER_LEAVE_TWO", null);
         }
     }
 
-    
+    private void handlePayout(Player one, Player two, int payout, int winner) {
+        UUID winnerId = (winner == 0)
+            ? (one != null ? one.getUniqueId() : null)
+            : (two != null ? two.getUniqueId() : null);
+        UUID loserId = (winner == 0)
+            ? (two != null ? two.getUniqueId() : null)
+            : (one != null ? one.getUniqueId() : null);
+
+        // Resolve fresh Player references by UUID rather than trusting the
+        // cached chair-occupant objects, which can go stale across a
+        // reconnect while the game was active (seating is locked while
+        // gameActive, so those fields can't be refreshed mid-round).
+        if (winnerId != null && payout > 0 && !forfeited.contains(winnerId)) {
+            Player winnerPlayer = Bukkit.getPlayer(winnerId);
+            if (winnerPlayer != null && winnerPlayer.isOnline()) {
+                creditPlayer(winnerPlayer, payout);
+                sendPayoutMessage(winnerPlayer, payout, true, payout/2);
+                applyWinEffects(winnerPlayer);
+            } else {
+                queuePendingPayout(winnerId, payout);
+            }
+        }
+
+        if (loserId != null && !forfeited.contains(loserId)) {
+            Player loserPlayer = Bukkit.getPlayer(loserId);
+            if (loserPlayer != null && loserPlayer.isOnline()) {
+                sendPayoutMessage(loserPlayer, payout, false, payout/2);
+                applyLoseEffects(loserPlayer);
+            }
+        }
+    }
+
+    private void queuePendingPayout(UUID playerId, double amount) {
+        Material currencyMaterial = plugin.getCurrency(internalName);
+        PendingPayout pendingPayout = PendingPayout.create(
+            playerId,
+            "Coin Flip",
+            internalName,
+            currencyMode,
+            currencyMaterial != null ? currencyMaterial.name() : null,
+            currencyName,
+            amount,
+            PayoutMessages.disconnectedMidGameContext("Coin Flip")
+        );
+        boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(pendingPayout);
+        if (!persisted) {
+            plugin.getLogger().warning("[NCCasino] Coin Flip pending payout failed to persist for " + playerId + ".");
+        }
+    }
+
+    /**
+     * Kicked players forfeit unconditionally, regardless of round phase —
+     * no refund, no pending payout. Pregame, this clears their seat/bet
+     * state directly (bypassing the normal PLAYER_LEAVE broadcast so their
+     * own already-removed client can't self-refund). Mid-round, it just
+     * marks them so handlePayout denies them even if they'd have won —
+     * resolveRound's existing post-payout cleanup frees the seat once the
+     * round ends.
+     */
+    void forfeitPlayer(UUID playerId) {
+        forfeited.add(playerId);
+
+        if (gameActive) {
+            return;
+        }
+
+        if (chairOneOccupant != null && chairOneOccupant.getUniqueId().equals(playerId)) {
+            if (chairTwoOccupant != null) {
+                chairOneOccupant = chairTwoOccupant;
+                chairTwoOccupant = null;
+                betAmount = 0;
+                broadcastUpdate("PLAYER_LEAVE_TWO", null);
+                broadcastUpdate("PLAYER_LEAVE_ONE", null);
+                broadcastUpdate("PLAYER_SIT_ONE", chairOneOccupant);
+            } else {
+                chairOneOccupant = null;
+                betAmount = 0;
+                broadcastUpdate("PLAYER_LEAVE_ONE", null);
+            }
+        } else if (chairTwoOccupant != null && chairTwoOccupant.getUniqueId().equals(playerId)) {
+            chairTwoOccupant = null;
+            broadcastUpdate("PLAYER_LEAVE_TWO", null);
+        }
+    }
+
     private void startTimer() {
         if (countdownTaskId != -1) return; // Timer is already running
 
         gameState = GameState.WAITING;
         timeLeft = plugin.getTimer(internalName);
-           
+
         countdownTaskId = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
             if (timeLeft <= 0) {
                 Bukkit.getScheduler().cancelTask(countdownTaskId);
@@ -171,6 +259,13 @@ public class CoinFlipServer extends Server {
                 // Otherwise, start the game
                 int winner = Math.random() < 0.5 ? 0 : 1;
                 broadcastUpdate("WINNER", winner);
+                // Resolve authoritatively on a fixed server-side delay
+                // rather than relying solely on a client to report its
+                // animation as finished — comfortably past the ~55-tick
+                // client-side animation, so in the normal case the
+                // client-driven ANIMATION_FINISHED still resolves first
+                // and this becomes a harmless no-op.
+                Bukkit.getScheduler().runTaskLater(plugin, () -> resolveRound(winner), 70L);
                 return;
             }
 

--- a/src/main/java/org/nc/nccasino/games/DragonDescent/DragonClient.java
+++ b/src/main/java/org/nc/nccasino/games/DragonDescent/DragonClient.java
@@ -21,24 +21,38 @@ import org.nc.nccasino.currency.MoneyHelper;
 import org.nc.nccasino.currency.VaultCurrencyProvider;
 import org.nc.nccasino.helpers.AttributeHelper;
 import org.nc.nccasino.helpers.SoundHelper;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class DragonClient extends Client{
-    private int numColumns = 7; 
+import java.util.UUID;
+
+public class DragonClient extends Client implements TerminableSession {
+    private int numColumns = 7;
     private int numSafeSpots = 5;
-    private int numRows = 4; 
+    private int numRows = 4;
     private int currentFloor = 1;
     private int playerX;
     private int[][] gameGrid;
-    private boolean moveLocked = false; 
+    private boolean moveLocked = false;
     private final List<Integer> taskIDs = new ArrayList<>();
     private boolean gameOverTriggered = false;
     private boolean playerLost = false;
-    private int displayOffset = 0; 
-    private int floorsCleared = 0; 
-    private boolean cashOutTriggered = false; 
+    private int displayOffset = 0;
+    private int floorsCleared = 0;
+    private boolean cashOutTriggered = false;
     private boolean shiftlock = false;
+    // Set synchronously the instant a floor click is accepted, cleared once
+    // the deferred task actually tallies it into floorsCleared. Lets a
+    // disconnect that lands inside that ~10-tick window still count the
+    // move instead of losing a floor the player already safely cleared.
+    private Boolean pendingMoveSafe = null;
+    private boolean sessionResolved = false;
     public DragonClient(DragonServer server, Player player, Nccasino plugin, String internalName) {
         super(server, player, "Dragon Descent", plugin, internalName);
+        SessionRegistry.register(player.getUniqueId(), this);
 
         if (!plugin.getConfig().contains("dealers." + internalName + ".default-columns")) {
             plugin.getConfig().set("dealers." + internalName + ".default-columns", 7);
@@ -505,7 +519,7 @@ public class DragonClient extends Client{
 
             if (!moveLocked && !cashOutTriggered && !playerLost) {
                 moveLocked=true;
-                cashOut(true);
+                cashOut();
             }
                 return;
         }
@@ -540,16 +554,18 @@ public class DragonClient extends Client{
             revealRow(floor);
             if(this.inventory == null||gameGrid==null) return;
             boolean gameOver = (gameGrid[displayOffset + floor - 1][safeGridCol] == 0);
-            if (gameOver) playerLost = true; 
+            if (gameOver) playerLost = true;
+            pendingMoveSafe = !gameOver;
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 if(this.inventory == null) return;
                 if (SoundHelper.getSoundSafely("block.cave_vines.step", player) != null)
                     player.playSound(player.getLocation(), Sound.BLOCK_CAVE_VINES_STEP, SoundCategory.MASTER, 1.0f, 1.0f);
                 inventory.setItem(playerX, createCustomItem(Material.VINE, "§aSafe!", 1));
                 playerX = slot;
-                if (gameGrid[displayOffset + floor - 1][safeGridCol] == 1) { 
+                if (gameGrid[displayOffset + floor - 1][safeGridCol] == 1) {
                     floorsCleared++; // Move this BEFORE updatePlayerHead
                 }
+                pendingMoveSafe = null;
                 updatePlayerHead();
         
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
@@ -563,7 +579,7 @@ public class DragonClient extends Client{
                         renameAllExcept(playerX, "§aYayyy!");
                         moveLocked = true; 
                         int taskID =Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                        cashOut(true); // Auto cash-out if at last floor
+                        cashOut(); // Auto cash-out if at last floor
                     }, 40L).getTaskId();
                     taskIDs.add(taskID);
                     } else if (floor == 5) { // Reached last visible row
@@ -751,8 +767,8 @@ public class DragonClient extends Client{
         }
     }
 
-    private void cashOut(boolean resetGame) {
-        if (cashOutTriggered) return; 
+    private void cashOut() {
+        if (cashOutTriggered) return;
         cashOutTriggered = true;
         moveLocked = true;
         double totalBet = betStack.stream().mapToDouble(Double::doubleValue).sum();
@@ -787,26 +803,7 @@ public class DragonClient extends Client{
         
         playerLost=true;
 
-        if(resetGame){
-            Bukkit.getScheduler().runTaskLater(plugin, this::resetGame, 40L); }
-        else{
-
-            betStack.clear(); // If rebet is off, clear the stack.
-            for (int taskID : taskIDs) {
-                Bukkit.getScheduler().cancelTask(taskID);
-            }
-            taskIDs.clear();
-            floorsCleared=0;
-            playerLost=false;
-            gameOverTriggered = false; // Reset game state
-            moveLocked = false;
-            displayOffset = 0;
-            currentFloor = 1;
-            playerX = 4;
-            gameGrid = null; // Clear old game grid safely
-            bettingEnabled = true;
-        }
-
+        Bukkit.getScheduler().runTaskLater(plugin, this::resetGame, 40L);
     }
 
     private void resetGame() {
@@ -864,19 +861,101 @@ public class DragonClient extends Client{
 
     @Override
     protected void handleClientInventoryClose() {
-        if(!bettingEnabled && !playerLost){
-            moveLocked=true;
-            cashOut(false);
-        }
-        else if (bettingEnabled && !betStack.isEmpty()) {
-            undoAllBets();
-        }
-        super.handleClientInventoryClose();
+        // Route through the same idempotent path used for quit/kick rather
+        // than resolving directly here — whichever of this or the quit
+        // event fires first "wins" and the other becomes a safe no-op, and
+        // consumeQuitReason still correctly reports KICKED here even if
+        // this fires first, since the kick is marked as soon as
+        // PlayerKickEvent itself fires.
+        UUID playerId = player.getUniqueId();
+        ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+        SessionRegistry.terminatePlayerSession(playerId, reason);
     }
-    
+
+    /**
+     * Authoritative disconnect/kick resolution, reached via SessionRegistry
+     * regardless of whether this fires from PlayerQuitEvent or from this
+     * client's own InventoryCloseEvent.
+     */
+    @Override
+    public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
+        if (sessionResolved) {
+            return; // already resolved through another path
+        }
+        sessionResolved = true;
+
+        if (reason != ExitReason.KICKED) {
+            if (bettingEnabled && !betStack.isEmpty()) {
+                undoAllBets();
+            } else if (!bettingEnabled && !playerLost) {
+                resolveMidGameDisconnect(terminatedPlayerId);
+            }
+            // playerLost already true: already resolved through normal
+            // play — either cashed out or the dragon already got them.
+        }
+        // KICKED: forfeit unconditionally regardless of phase — no refund,
+        // no cash-out.
+
+        betStack.clear();
+
+        for (int taskId : taskIDs) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+        taskIDs.clear();
+
+        server.removeClient(terminatedPlayerId);
+    }
+
+    /**
+     * Cashes out the player's current position (bet x multiplier for
+     * floorsCleared, finishing the tally of an in-flight accepted move if
+     * one hadn't been applied yet) as a durable pending payout for delivery
+     * on reconnect. This deliberately never attempts a direct credit here:
+     * whether the Player object is still safely usable at the exact moment
+     * this runs isn't reliably knowable, so risking a lost payout for
+     * slightly faster delivery isn't an acceptable trade.
+     */
+    private void resolveMidGameDisconnect(UUID terminatedPlayerId) {
+        if (Boolean.TRUE.equals(pendingMoveSafe)) {
+            floorsCleared++;
+        }
+        pendingMoveSafe = null;
+
+        double totalBet = betStack.stream().mapToDouble(Double::doubleValue).sum();
+        double winnings = totalBet * calculatePayoutMultiplier();
+        if (winnings <= 0) {
+            return;
+        }
+
+        Material currencyMaterial = plugin.getCurrency(internalName);
+        PendingPayout payout = PendingPayout.create(
+            terminatedPlayerId,
+            "Dragon Descent",
+            internalName,
+            currencyMode,
+            currencyMaterial != null ? currencyMaterial.name() : null,
+            currencyName,
+            winnings,
+            PayoutMessages.disconnectedMidGameContext("Dragon Descent")
+        );
+
+        boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
+        if (!persisted) {
+            // Durable write failed. Rather than losing the winnings
+            // outright, make a best-effort direct credit attempt as a
+            // last resort — not guaranteed to reach the player, but
+            // strictly better odds than doing nothing.
+            plugin.getLogger().warning("[NCCasino] Dragon Descent pending payout failed to persist for "
+                + terminatedPlayerId + "; attempting direct credit instead.");
+            if (player != null) {
+                creditPlayer(player, winnings);
+            }
+        }
+    }
+
     @Override
     public void onServerUpdate(String eventType, Object data) {
         throw new UnsupportedOperationException("Unimplemented method 'onServerUpdate'");
     }
-    
+
 }

--- a/src/main/java/org/nc/nccasino/games/DragonDescent/DragonClient.java
+++ b/src/main/java/org/nc/nccasino/games/DragonDescent/DragonClient.java
@@ -24,6 +24,7 @@ import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.payout.PayoutMessages;
 import org.nc.nccasino.payout.PendingPayout;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -884,12 +885,20 @@ public class DragonClient extends Client implements TerminableSession {
         }
         sessionResolved = true;
 
-        if (reason != ExitReason.KICKED) {
-            if (bettingEnabled && !betStack.isEmpty()) {
+        switch (GameTerminationPolicy.dragon(reason, bettingEnabled, playerLost)) {
+        case REFUND:
+            if (!betStack.isEmpty()) {
                 undoAllBets();
-            } else if (!bettingEnabled && !playerLost) {
-                resolveMidGameDisconnect(terminatedPlayerId);
             }
+            break;
+        case CASH_OUT:
+            resolveMidGameDisconnect(terminatedPlayerId);
+            break;
+        case NO_ACTION:
+        case FORFEIT:
+            break;
+        default:
+            throw new IllegalStateException("Unexpected Dragon Descent termination action");
             // playerLost already true: already resolved through normal
             // play — either cashed out or the dragon already got them.
         }

--- a/src/main/java/org/nc/nccasino/games/Mines/MinesInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Mines/MinesInventory.java
@@ -7,6 +7,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.nc.nccasino.Nccasino;
 import org.bukkit.event.HandlerList;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,13 +55,26 @@ public class MinesInventory extends DealerInventory {
             if (player.getInventory() != null) {
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     if (player.getOpenInventory().getTopInventory().getHolder() == this.getInventory().getHolder()) {
-                 
+
+                        UUID playerId = player.getUniqueId();
+                        if (Tables.containsKey(playerId)) {
+                            // A table from a previous session is still on
+                            // record for this UUID — never let a
+                            // reconnecting player join a second, orphaned
+                            // table. Resolve it through the normal
+                            // disconnect path first (idempotent: a no-op
+                            // if it was already properly cleaned up), then
+                            // guarantee it's gone from Tables regardless.
+                            SessionRegistry.terminatePlayerSession(playerId, ExitReason.DISCONNECTED);
+                            removeTable(playerId);
+                        }
+
                         MinesTable minesTable = new MinesTable(dealerId, player, plugin, internalName, this);
-                        Tables.put(player.getUniqueId(), minesTable);
+                        Tables.put(playerId, minesTable);
                         minesTable.initializeTable();
                         player.openInventory(minesTable.getInventory());
                     }
-                   
+
                 }, 2L);
             }
         }

--- a/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
+++ b/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
@@ -36,8 +36,13 @@ import org.nc.nccasino.currency.MoneyHelper;
 import org.nc.nccasino.currency.VaultCurrencyProvider;
 import org.nc.nccasino.entities.DealerInventory;
 import org.nc.nccasino.helpers.SoundHelper;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class MinesTable extends DealerInventory {
+public class MinesTable extends DealerInventory implements TerminableSession {
     // Game state management
     public enum GameState {
         PLACING_WAGER,
@@ -145,6 +150,7 @@ public class MinesTable extends DealerInventory {
         this.gameOver = false;
         int defMines;
         this.dealerId = dealerId;
+        SessionRegistry.register(playerId, this);
 
         loadChipValuesFromConfig();
         if (!plugin.getConfig().contains("dealers." + internalName + ".default-mines")) {
@@ -1669,7 +1675,8 @@ public class MinesTable extends DealerInventory {
 
         // Notify minesInventory to remove the player's table
         minesInventory.removeTable(playerId);
-    
+        SessionRegistry.unregister(playerId, this);
+
         cleanup();  // Clean up game state
     }
     
@@ -1692,12 +1699,108 @@ public class MinesTable extends DealerInventory {
     // Handle inventory close event
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getInventory().getHolder() instanceof MinesTable) || !event.getPlayer().getUniqueId().equals(playerId)) {
+            return;
+        }
 
-        if (event.getInventory().getHolder() instanceof MinesTable && event.getPlayer().getUniqueId().equals(playerId)) {
-            if (gameState == GameState.PLAYING) {
-                closeCashOut();  // Automatically cash out the player
+        // Route through the same idempotent path used for quit/kick rather
+        // than resolving directly here. It's unclear whether
+        // InventoryCloseEvent reliably fires on a real disconnect, so this
+        // must not race ahead of PlayerQuitEvent and get it wrong (e.g.
+        // cashing out a kicked player) — whichever of this or the quit
+        // event fires first "wins" and the other becomes a safe no-op, and
+        // consumeQuitReason still correctly reports KICKED here even if
+        // this fires first, since the kick is marked as soon as
+        // PlayerKickEvent itself fires.
+        ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+        SessionRegistry.terminatePlayerSession(playerId, reason);
+    }
+
+    /**
+     * Authoritative disconnect/kick resolution, reached via SessionRegistry
+     * regardless of whether this fires from PlayerQuitEvent or from this
+     * table's own InventoryCloseEvent. Mines resolves each tile click
+     * synchronously (gameState/safePicks/gameOver are already fully
+     * updated the instant a click is accepted, before any reveal
+     * animation runs), so whatever this table's state shows at the moment
+     * of termination already reflects the true, finished outcome of the
+     * last accepted move — there is no separate "still resolving" state
+     * to wait for.
+     */
+    @Override
+    public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
+        if (Boolean.TRUE.equals(closeFlag)) {
+            return; // already resolved through another path
+        }
+        closeFlag = true;
+
+        if (reason != ExitReason.KICKED) {
+            if (gameState == GameState.PLACING_WAGER || gameState == GameState.WAITING_TO_START) {
+                refundAllBets(player);
+            } else if (gameState == GameState.PLAYING) {
+                resolveMidGameDisconnect(terminatedPlayerId);
             }
-            endGame();  // Call the end game logic when the inventory is closed
+            // GAME_OVER: already resolved through normal play — either a
+            // win was already paid, or a mine was hit and nothing is owed.
+        }
+        // KICKED: forfeit unconditionally regardless of phase — no refund,
+        // no cash-out.
+
+        betStack.clear();
+
+        for (int taskId : scheduledTasks) {
+            Bukkit.getScheduler().cancelTask(taskId);
+        }
+        scheduledTasks.clear();
+
+        minesInventory.removeTable(terminatedPlayerId);
+        unregisterListener();
+    }
+
+    /**
+     * Cashes out the player's current position (bet x current multiplier)
+     * as a durable pending payout for delivery on reconnect, per the
+     * required policy. This deliberately never attempts a direct credit
+     * here: whether a Player object is still safely usable at the exact
+     * moment this runs is not reliably knowable (it's unclear whether
+     * InventoryCloseEvent fires before or after connection teardown
+     * begins on a real disconnect), so silently risking a lost payout in
+     * exchange for slightly faster delivery in the ambiguous cases is not
+     * an acceptable trade.
+     */
+    private void resolveMidGameDisconnect(UUID terminatedPlayerId) {
+        double totalBet = 0;
+        for (double t : betStack) {
+            totalBet += t;
+        }
+        double winnings = safePicks == 0 ? totalBet : totalBet * calculatePayoutMultiplier(safePicks);
+        if (winnings <= 0) {
+            return;
+        }
+
+        Material currencyMaterial = plugin.getCurrency(internalName);
+        PendingPayout payout = PendingPayout.create(
+            terminatedPlayerId,
+            "Mines",
+            internalName,
+            currencyMode,
+            currencyMaterial != null ? currencyMaterial.name() : null,
+            currencyName,
+            winnings,
+            PayoutMessages.disconnectedMidGameContext("Mines")
+        );
+
+        boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
+        if (!persisted) {
+            // Durable write failed. Rather than losing the winnings
+            // outright, make a best-effort direct credit attempt as a
+            // last resort — not guaranteed to reach the player, but
+            // strictly better odds than doing nothing.
+            plugin.getLogger().warning("[NCCasino] Mines pending payout failed to persist for "
+                + terminatedPlayerId + "; attempting direct credit instead.");
+            if (player != null) {
+                giveWinningsToPlayer(winnings);
+            }
         }
     }
 

--- a/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
+++ b/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
@@ -75,7 +75,14 @@ public class MinesTable extends DealerInventory implements TerminableSession {
     private double previousWager = 0.0; // New field to store previous wager
     private boolean[][] fireGrid; // [6][9] To track which tiles are on fire
     private final List<Integer> scheduledTasks = new ArrayList<>();
-    private boolean rebetEnabled = false; 
+    private boolean rebetEnabled = false;
+    // Set the instant cashOut() commits to paying out (alongside gameOver/
+    // gameState flipping to GAME_OVER), cleared once that deferred deposit
+    // actually completes. Lets onSessionTerminated tell "already paid or
+    // lost" apart from "paying out is in flight, ~10 ticks away" on a
+    // plugin/server shutdown, where that deferred task would otherwise be
+    // cancelled by Bukkit before it ever runs.
+    private boolean cashOutDepositPending = false;
     // Adjusted fields for grid mapping
     private final int[] gridSlots = {
         2, 3, 4, 5, 6,
@@ -542,11 +549,11 @@ public class MinesTable extends DealerInventory implements TerminableSession {
                 return;
             }
             // place that entire count as a single bet in the betStack
-            betStack.push((double) count);
             boolean removed = removeWagerFromInventory(player, count);
 			if (!removed) {
 				return;
 			}
+            betStack.push((double) count);
             double totalBet = betStack.stream().mapToDouble(d -> d).sum();
             updateBetLore(53, totalBet);
             wager = count;
@@ -1157,6 +1164,7 @@ public class MinesTable extends DealerInventory implements TerminableSession {
         // window queue a second, independent payout for the same cash-out.
         gameOver = true;
         gameState = GameState.GAME_OVER;
+        cashOutDepositPending = true;
 
         // Step 1: Reveal all tiles (mines and safes)
         revealAllTiles();
@@ -1228,6 +1236,8 @@ public class MinesTable extends DealerInventory implements TerminableSession {
 				} 
 				giveWinningsToPlayer(winnings);
 			}
+
+            cashOutDepositPending = false;
 
             // Reset the game after a delay
             Bukkit.getScheduler().runTaskLater(plugin, this::resetGame, 20L); // Wait 5 seconds before resetting
@@ -1520,8 +1530,8 @@ public class MinesTable extends DealerInventory implements TerminableSession {
 				return withdrawn >= amount;
 			}
 
-            provider.withdraw(player, internalName, amount);
-            return true;
+            int withdrawn = provider.withdraw(player, internalName, amount);
+            return withdrawn >= amount;
         }
 
         Material currencyMat = plugin.getCurrency(internalName);
@@ -1746,9 +1756,22 @@ public class MinesTable extends DealerInventory implements TerminableSession {
                 refundAllBets(player);
             } else if (gameState == GameState.PLAYING) {
                 resolveMidGameDisconnect(terminatedPlayerId);
+            } else if (gameState == GameState.GAME_OVER && cashOutDepositPending && reason == ExitReason.PLUGIN_DISABLE) {
+                // cashOut() already committed to paying out (gameOver/
+                // gameState flipped synchronously), but the actual deposit
+                // is still a few ticks away in a task that's about to be
+                // cancelled along with everything else the plugin owns.
+                // Queue the same already-known payout durably instead of
+                // letting it be silently cancelled and lost. Deliberately
+                // scoped to PLUGIN_DISABLE only: for a plain disconnect in
+                // this same window, the still-live scheduled task is NOT
+                // cancelled and will complete on its own — queuing a
+                // second payout here would double-pay it.
+                resolveMidGameDisconnect(terminatedPlayerId);
             }
-            // GAME_OVER: already resolved through normal play — either a
-            // win was already paid, or a mine was hit and nothing is owed.
+            // GAME_OVER otherwise: already resolved through normal play —
+            // either a win was already paid, a mine was hit and nothing is
+            // owed, or a live cash-out deposit is still safely in flight.
         }
         // KICKED: forfeit unconditionally regardless of phase — no refund,
         // no cash-out.

--- a/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
+++ b/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
@@ -1147,7 +1147,17 @@ public class MinesTable extends DealerInventory implements TerminableSession {
             //player.sendMessage("§cGame over.");
             return;
         }
-    
+
+        // Mark the game resolved synchronously, before any of the payout
+        // itself runs — mirroring how a mine hit already does this. The
+        // actual deposit below is deferred behind a scheduled task, but
+        // onSessionTerminated relies on gameState to know whether a
+        // disconnect still needs resolving; leaving it at PLAYING until
+        // after the deposit already happened let a disconnect in that
+        // window queue a second, independent payout for the same cash-out.
+        gameOver = true;
+        gameState = GameState.GAME_OVER;
+
         // Step 1: Reveal all tiles (mines and safes)
         revealAllTiles();
         player.getWorld().spawnParticle(Particle.GLOW, player.getLocation(), 50);
@@ -1218,10 +1228,7 @@ public class MinesTable extends DealerInventory implements TerminableSession {
 				} 
 				giveWinningsToPlayer(winnings);
 			}
-       
-            gameOver = true;
-            gameState = GameState.GAME_OVER;
-    
+
             // Reset the game after a delay
             Bukkit.getScheduler().runTaskLater(plugin, this::resetGame, 20L); // Wait 5 seconds before resetting
     

--- a/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
+++ b/src/main/java/org/nc/nccasino/games/Mines/MinesTable.java
@@ -39,6 +39,8 @@ import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.payout.PayoutMessages;
 import org.nc.nccasino.payout.PendingPayout;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
+import org.nc.nccasino.session.TerminationAction;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -1751,22 +1753,28 @@ public class MinesTable extends DealerInventory implements TerminableSession {
         }
         closeFlag = true;
 
-        if (reason != ExitReason.KICKED) {
-            if (gameState == GameState.PLACING_WAGER || gameState == GameState.WAITING_TO_START) {
+        GameTerminationPolicy.MinesPhase phase =
+            gameState == GameState.PLACING_WAGER || gameState == GameState.WAITING_TO_START
+                ? GameTerminationPolicy.MinesPhase.PREGAME
+                : gameState == GameState.PLAYING
+                    ? GameTerminationPolicy.MinesPhase.PLAYING
+                    : gameState == GameState.GAME_OVER && cashOutDepositPending
+                        ? GameTerminationPolicy.MinesPhase.GAME_OVER_DEPOSIT_PENDING
+                        : GameTerminationPolicy.MinesPhase.RESOLVED;
+        TerminationAction action = GameTerminationPolicy.mines(reason, phase);
+
+        if (action != TerminationAction.FORFEIT) {
+            if (action == TerminationAction.REFUND) {
                 refundAllBets(player);
-            } else if (gameState == GameState.PLAYING) {
+            } else if (action == TerminationAction.CASH_OUT
+                && phase == GameTerminationPolicy.MinesPhase.PLAYING) {
                 resolveMidGameDisconnect(terminatedPlayerId);
-            } else if (gameState == GameState.GAME_OVER && cashOutDepositPending && reason == ExitReason.PLUGIN_DISABLE) {
-                // cashOut() already committed to paying out (gameOver/
-                // gameState flipped synchronously), but the actual deposit
-                // is still a few ticks away in a task that's about to be
-                // cancelled along with everything else the plugin owns.
-                // Queue the same already-known payout durably instead of
-                // letting it be silently cancelled and lost. Deliberately
-                // scoped to PLUGIN_DISABLE only: for a plain disconnect in
-                // this same window, the still-live scheduled task is NOT
-                // cancelled and will complete on its own — queuing a
-                // second payout here would double-pay it.
+            }
+            if (phase == GameTerminationPolicy.MinesPhase.GAME_OVER_DEPOSIT_PENDING
+                && action == TerminationAction.CASH_OUT) {
+                // cashOut() committed the amount, but its deposit is still
+                // delayed. Persist it before this path cancels the task and
+                // clears betStack.
                 resolveMidGameDisconnect(terminatedPlayerId);
             }
             // GAME_OVER otherwise: already resolved through normal play —

--- a/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
@@ -546,9 +546,10 @@ public class BettingTable extends DealerInventory {
                     }
                 }
                 if (totalPayoutFinal > 0) {
-                    refundWagerToInventory(player, totalPayoutFinal);
-                    rouletteInventory.clearOnlineDepositPending(playerId);
-                    rouletteInventory.finalizeRoundResolution(playerId);
+                    if (rouletteInventory.claimOnlineDeposit(playerId, totalPayoutFinal)) {
+                        refundWagerToInventory(player, totalPayoutFinal);
+                        rouletteInventory.finalizeRoundResolution(playerId);
+                    }
                 }
             }, 20L);
             Bukkit.getScheduler().runTaskLater(plugin, this::initializeTable, 25L);

--- a/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
@@ -523,6 +523,15 @@ public class BettingTable extends DealerInventory {
                 }, 20L);
             }
 
+            if (totalPayoutFinal > 0) {
+                // A shutdown landing in the ~1s window before the deposit
+                // below runs would otherwise cancel it silently, or (since
+                // finalizeRoundResolution hasn't cleared Bets yet either)
+                // fall back to refunding just the stake instead of the
+                // winnings — mark the already-known payout so it's queued
+                // durably and correctly if that happens.
+                rouletteInventory.markOnlineDepositPending(playerId, totalPayoutFinal);
+            }
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
                     case STANDARD:{
@@ -538,10 +547,15 @@ public class BettingTable extends DealerInventory {
                 }
                 if (totalPayoutFinal > 0) {
                     refundWagerToInventory(player, totalPayoutFinal);
+                    rouletteInventory.clearOnlineDepositPending(playerId);
+                    rouletteInventory.finalizeRoundResolution(playerId);
                 }
             }, 20L);
             Bukkit.getScheduler().runTaskLater(plugin, this::initializeTable, 25L);
             Bukkit.getScheduler().runTaskLater(plugin, this::updateAllLore, 25L);
+            if (totalPayoutFinal <= 0) {
+                rouletteInventory.finalizeRoundResolution(playerId);
+            }
         } else if (totalPayoutFinal > 0) {
             // Offline at resolution time: the outcome is already final and
             // owed regardless of presence, but crediting a currently-dead
@@ -562,9 +576,10 @@ public class BettingTable extends DealerInventory {
             if (!persisted) {
                 plugin.getLogger().warning("[NCCasino] Roulette pending payout failed to persist for " + playerId + ".");
             }
+            rouletteInventory.finalizeRoundResolution(playerId);
+        } else {
+            rouletteInventory.finalizeRoundResolution(playerId);
         }
-
-        rouletteInventory.finalizeRoundResolution(playerId);
     }
     
     private String parseCategory(String betType) {

--- a/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/BettingTable.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -26,10 +27,12 @@ import org.nc.nccasino.currency.CurrencyProvider;
 import org.nc.nccasino.currency.MoneyHelper;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.helpers.Preferences;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
 import java.util.*;
 
 public class BettingTable extends DealerInventory {
-    public static final Set<Player> switchingPlayers = new HashSet<>();
+    public static final Set<UUID> switchingPlayers = new HashSet<>();
     private final UUID playerId;
     public final UUID dealerId;
     private final Mob dealer;
@@ -413,8 +416,6 @@ public class BettingTable extends DealerInventory {
     }
 
     public void processSpinResult(int result, Stack<Pair<String, Integer>> dastack) {
-        Player player = Bukkit.getPlayer(playerId);
-        if (player == null) return;
         int overallWager=0;
         // We'll group categories into a data structure
         class BetCategory {
@@ -466,81 +467,104 @@ public class BettingTable extends DealerInventory {
             }
         }
     
-        // Build result message
-        StringBuilder msg = new StringBuilder("§e----- Spin Results -----\n");
-        TableGenerator table = new TableGenerator(TableGenerator.Alignment.LEFT, TableGenerator.Alignment.RIGHT, TableGenerator.Alignment.RIGHT);
-        table.addRow("§eCategory", "§bWager", "§aPayout");
-    
-        for (Map.Entry<String, BetCategory> entry : categoryMap.entrySet()) {
-            BetCategory cat = entry.getValue();
-            table.addRow("§e" + entry.getKey(), "§b" + cat.totalWager, (cat.totalPayout > 0 ? "§a" + cat.totalPayout : "§c0"));
-        }
-    
-        List<String> tableLines = table.generate(TableGenerator.Receiver.CLIENT, false, false);
-        for (String line : tableLines) {
-            msg.append(line).append("\n");
-        }
-    
-        msg.append("\n");
-        if (totalPayout > 0) {
-            //msg.append("§bTotal Wager: ").append(overallWager+"§e | ");
-            //msg.append("§aTotal Payout: ").append(totalPayout).append("\n");
+        final int totalPayoutFinal = categoryMap.values().stream().mapToInt(cat -> cat.totalPayout).sum();
+        Player player = Bukkit.getPlayer(playerId);
 
-            if(totalPayout-overallWager>0){
-                msg.append("§a§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n §r§a§o(profit of "+(totalPayout-overallWager)+")");
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                    player.getWorld().spawnParticle(Particle.GLOW, player.getLocation(), 50);
-                    Random random = new Random();
-                    float[] possiblePitches = {0.5f, 0.8f, 1.2f, 1.5f, 1.8f,0.7f, 0.9f, 1.1f, 1.4f, 1.9f};
-                    for (int i = 0; i < 3; i++) {
-                        float chosenPitch = possiblePitches[random.nextInt(possiblePitches.length)];
-                         if (SoundHelper.getSoundSafely("entity.player.levelup", player)!= null)player.playSound(player.getLocation(),  Sound.ENTITY_PLAYER_LEVELUP,SoundCategory.MASTER,1.0f, chosenPitch);
-                    }
-    
-                }, 20L);  
+        if (player != null && player.isOnline()) {
+            // Build result message
+            StringBuilder msg = new StringBuilder("§e----- Spin Results -----\n");
+            TableGenerator table = new TableGenerator(TableGenerator.Alignment.LEFT, TableGenerator.Alignment.RIGHT, TableGenerator.Alignment.RIGHT);
+            table.addRow("§eCategory", "§bWager", "§aPayout");
+
+            for (Map.Entry<String, BetCategory> entry : categoryMap.entrySet()) {
+                BetCategory cat = entry.getValue();
+                table.addRow("§e" + entry.getKey(), "§b" + cat.totalWager, (cat.totalPayout > 0 ? "§a" + cat.totalPayout : "§c0"));
             }
-            else if(totalPayout-overallWager==0){ 
-                msg.append("§6§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n §r§6§o (broke even)");
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                     if (SoundHelper.getSoundSafely("item.shield.break", player) != null)player.playSound(player.getLocation(), Sound.ITEM_SHIELD_BREAK,SoundCategory.MASTER,1.0f, 1.0f);
-                    player.getWorld().spawnParticle(Particle.SCRAPE, player.getLocation(), 20); 
-                }, 20L);  
+
+            List<String> tableLines = table.generate(TableGenerator.Receiver.CLIENT, false, false);
+            for (String line : tableLines) {
+                msg.append(line).append("\n");
             }
-            else{
+
+            msg.append("\n");
+            if (totalPayout > 0) {
+                if(totalPayout-overallWager>0){
+                    msg.append("§a§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n §r§a§o(profit of "+(totalPayout-overallWager)+")");
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        player.getWorld().spawnParticle(Particle.GLOW, player.getLocation(), 50);
+                        Random random = new Random();
+                        float[] possiblePitches = {0.5f, 0.8f, 1.2f, 1.5f, 1.8f,0.7f, 0.9f, 1.1f, 1.4f, 1.9f};
+                        for (int i = 0; i < 3; i++) {
+                            float chosenPitch = possiblePitches[random.nextInt(possiblePitches.length)];
+                             if (SoundHelper.getSoundSafely("entity.player.levelup", player)!= null)player.playSound(player.getLocation(),  Sound.ENTITY_PLAYER_LEVELUP,SoundCategory.MASTER,1.0f, chosenPitch);
+                        }
+
+                    }, 20L);
+                }
+                else if(totalPayout-overallWager==0){
+                    msg.append("§6§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n §r§6§o (broke even)");
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                         if (SoundHelper.getSoundSafely("item.shield.break", player) != null)player.playSound(player.getLocation(), Sound.ITEM_SHIELD_BREAK,SoundCategory.MASTER,1.0f, 1.0f);
+                        player.getWorld().spawnParticle(Particle.SCRAPE, player.getLocation(), 20);
+                    }, 20L);
+                }
+                else{
+                    msg.append("§c§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n§r§c§o  (loss of "+Math.abs(totalPayout-overallWager)+")");
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                         if (SoundHelper.getSoundSafely("entity.generic.explode", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, SoundCategory.MASTER,1.0f, 1.0f);
+                        player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20);
+                    }, 20L);
+                }
+            } else {
                 msg.append("§c§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n§r§c§o  (loss of "+Math.abs(totalPayout-overallWager)+")");
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
                      if (SoundHelper.getSoundSafely("entity.generic.explode", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, SoundCategory.MASTER,1.0f, 1.0f);
-                    player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20); 
-                }, 20L);  
+                    player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20);
+                }, 20L);
             }
-        } else {
-            msg.append("§c§lPaid ").append(plugin.formatWagerDisplay(currencyMode, currencyName, totalPayout)).append("\n§r§c§o  (loss of "+Math.abs(totalPayout-overallWager)+")");
+
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                 if (SoundHelper.getSoundSafely("entity.generic.explode", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, SoundCategory.MASTER,1.0f, 1.0f);
-                player.getWorld().spawnParticle(Particle.EXPLOSION, player.getLocation(), 20); 
-            }, 20L);  
-        }
-    
-        final int totalPayoutFinal = categoryMap.values().stream().mapToInt(cat -> cat.totalPayout).sum();
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-                case STANDARD:{
-                    player.sendMessage(msg.toString());
-                    break;}
-                case VERBOSE:{
-                    player.sendMessage(msg.toString());
-                    break;     
+                switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
+                    case STANDARD:{
+                        player.sendMessage(msg.toString());
+                        break;}
+                    case VERBOSE:{
+                        player.sendMessage(msg.toString());
+                        break;
+                    }
+                        case NONE:{
+                        break;
+                    }
                 }
-                    case NONE:{
-                    break;
+                if (totalPayoutFinal > 0) {
+                    refundWagerToInventory(player, totalPayoutFinal);
                 }
-            } 
-            if (totalPayoutFinal > 0) {
-                refundWagerToInventory(player, totalPayoutFinal);
+            }, 20L);
+            Bukkit.getScheduler().runTaskLater(plugin, this::initializeTable, 25L);
+            Bukkit.getScheduler().runTaskLater(plugin, this::updateAllLore, 25L);
+        } else if (totalPayoutFinal > 0) {
+            // Offline at resolution time: the outcome is already final and
+            // owed regardless of presence, but crediting a currently-dead
+            // Player reference isn't safe — queue it durably instead and
+            // deliver it on reconnect.
+            Material currencyMaterial = plugin.getCurrency(internalName);
+            PendingPayout payout = PendingPayout.create(
+                playerId,
+                "Roulette",
+                internalName,
+                currencyMode,
+                currencyMaterial != null ? currencyMaterial.name() : null,
+                currencyName,
+                totalPayoutFinal,
+                PayoutMessages.disconnectedMidGameContext("Roulette")
+            );
+            boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
+            if (!persisted) {
+                plugin.getLogger().warning("[NCCasino] Roulette pending payout failed to persist for " + playerId + ".");
             }
-        }, 20L);
-        Bukkit.getScheduler().runTaskLater(plugin, this::initializeTable, 25L);
-        Bukkit.getScheduler().runTaskLater(plugin, this::updateAllLore, 25L);
+        }
+
+        rouletteInventory.finalizeRoundResolution(playerId);
     }
     
     private String parseCategory(String betType) {
@@ -946,16 +970,16 @@ public class BettingTable extends DealerInventory {
                 plugin.getLogger().warning("Error: Unable to find Roulette inventory for dealer ID: " + dealerId);
                  if (SoundHelper.getSoundSafely("entity.villager.no", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, SoundCategory.MASTER,1.0f, 1.0f); 
             } else if (dealerInventory instanceof RouletteInventory) {
-                switchingPlayers.add(player);
+                switchingPlayers.add(player.getUniqueId());
                 if (plugin.getPreferences(player.getUniqueId()).getSoundSetting() == Preferences.SoundSetting.ON) {
                 rouletteInventory.getMCE().addPlayerToChannel("RouletteWheel", player);
                 rouletteInventory.getMCE().removePlayerFromChannel("BettingTable", player);
                 }
                 player.openInventory(((RouletteInventory) dealerInventory).getInventory());
-                 if (SoundHelper.getSoundSafely("item.chorus_fruit.teleport", player) != null)player.playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.MASTER,1.0f, 1.0f); 
+                 if (SoundHelper.getSoundSafely("item.chorus_fruit.teleport", player) != null)player.playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.MASTER,1.0f, 1.0f);
                  Bukkit.getScheduler().runTaskLater(plugin, () -> {
 
-                switchingPlayers.remove(player);
+                switchingPlayers.remove(player.getUniqueId());
                  },5L);
             } else {
                 player.sendMessage("Error: This dealer is not running Roulette.");
@@ -1113,34 +1137,45 @@ private boolean isValidSlotPage2(int slot) {
     
     @EventHandler
     public void handlePlayerQuit(PlayerQuitEvent event) {
-        switchingPlayers.remove(event.getPlayer());
+        switchingPlayers.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler
     public void handleInventoryClose(InventoryCloseEvent event) {
         if (event.getInventory().getHolder() != this) return;
         Player player = (Player) event.getPlayer();
-       
-        if (switchingPlayers.contains(player)) {
+
+        if (switchingPlayers.contains(playerId)) {
 
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                switchingPlayers.remove(player);
+                switchingPlayers.remove(playerId);
                  },20L);
             return;
         }
 
-        if (!betStack.isEmpty()){
-            rouletteInventory.updatePlayerBets(player.getUniqueId(),betStack,player);
-
-        }
-        else{
-            rouletteInventory.removeFromBets(player.getUniqueId());
-
+        // Only persist betStack back into the shared Bets map if this is
+        // still the live, current table for this player. If it's been
+        // superseded (a kick forfeited this UUID's bet, or a prior round
+        // already fully resolved and cleaned it up), rouletteInventory.Tables
+        // no longer points at this instance, and writing betStack back here
+        // would silently resurrect a bet that was already correctly
+        // removed.
+        if (rouletteInventory.Tables.get(playerId) == this) {
+            if (!betStack.isEmpty()){
+                rouletteInventory.updatePlayerBets(playerId,betStack,player);
+            }
+            else{
+                rouletteInventory.removeFromBets(playerId);
+            }
         }
         InventoryView closedInventory = event.getView();
         if (closedInventory != null && closedInventory.getTopInventory().getHolder() == this) {
         rouletteInventory.getMCE().removePlayerFromAllChannels(player);
     }
+    }
+
+    void cleanupListener() {
+        HandlerList.unregisterAll(this);
     }
 
     private void updateItemLore(int slot, int totalBet) {
@@ -1238,15 +1273,15 @@ private boolean isValidSlotPage2(int slot) {
             plugin.getLogger().warning("Error: Unable to find Roulette inventory for dealer ID: " + dealerId);
              if (SoundHelper.getSoundSafely("entity.villager.no", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, SoundCategory.MASTER,1.0f, 1.0f); 
         } else if (dealerInventory instanceof RouletteInventory) {
-            switchingPlayers.add(player);
+            switchingPlayers.add(player.getUniqueId());
             if (plugin.getPreferences(player.getUniqueId()).getSoundSetting() == Preferences.SoundSetting.ON) {
 
             rouletteInventory.getMCE().addPlayerToChannel("RouletteWheel", player);
             rouletteInventory.getMCE().removePlayerFromChannel("BettingTable", player);
             }
             player.openInventory(((RouletteInventory) dealerInventory).getInventory());
-             if (SoundHelper.getSoundSafely("item.chorus_fruit.teleport", player) != null)player.playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.MASTER,1.0f, 1.0f); 
-            switchingPlayers.remove(player);
+             if (SoundHelper.getSoundSafely("item.chorus_fruit.teleport", player) != null)player.playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.MASTER,1.0f, 1.0f);
+            switchingPlayers.remove(player.getUniqueId());
         } else {
             player.sendMessage("Error: This dealer is not running Roulette.");
              if (SoundHelper.getSoundSafely("entity.villager.no", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, SoundCategory.MASTER,1.0f, 1.0f); 

--- a/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
@@ -39,6 +39,7 @@ import org.nc.nccasino.helpers.Preferences;
 import org.nc.nccasino.payout.PayoutMessages;
 import org.nc.nccasino.payout.PendingPayout;
 import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.GameTerminationPolicy;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
 
@@ -1242,27 +1243,24 @@ private void handleWinningNumber() {
     finalpicked = true;
 
     mce.playSong("RouletteWheel", RouletteSongs.getFinalSpot(), false, "Final spot");
-    // Loop over players who have placed bets. Scheduled and resolved by
-    // UUID regardless of current online status — the bet already rode the
-    // spin, so it's owed a real outcome either way (processSpinResult
-    // itself decides direct credit vs. a durable pending payout based on
-    // whether the player is back online by the time this runs).
-    for (UUID playerId : playersWithBets) {
-        // Schedule the processing to run after a delay
+    // Resolve by UUID regardless of current online status. The bet already
+    // rode the spin, so it is owed the real result either way.
+    for (UUID playerId : new ArrayList<>(playersWithBets)) {
+        BettingTable bettingTable = Tables.get(playerId);
+        Stack<Pair<String, Integer>> playerBets = newtry.get(playerId);
+        if (bettingTable == null) {
+            plugin.getLogger().warning("No betting table found for player: " + playerId);
+            continue;
+        }
+        if (playerBets == null || playerBets.isEmpty()) {
+            plugin.getLogger().warning(playerId + " has no bets to process.");
+            continue;
+        }
+        // The final slot is authoritative now. Commit money before the
+        // delayed presentation so shutdown cannot refund a resolved spin.
+        bettingTable.processSpinResult(winningNumber, playerBets);
+
         miscTask=Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            BettingTable bettingTable = Tables.get(playerId);
-            if (bettingTable == null) {
-                plugin.getLogger().warning("No betting table found for player: " + playerId);
-                return;
-            }
-
-            // Get the bet stack directly from the BettingTable
-            Stack<Pair<String, Integer>> playerBets = newtry.get(playerId);
-            if (playerBets == null || playerBets.isEmpty()) {
-                plugin.getLogger().warning(playerId + " has no bets to process.");
-                return;
-            }
-
             Player player = Bukkit.getPlayer(playerId);
             if (player != null) {
                 // Notify the player of the winning number
@@ -1308,8 +1306,6 @@ private void handleWinningNumber() {
                 }
             }
 
-            // Process the bets
-            bettingTable.processSpinResult(winningNumber, playerBets);
         }, 30L);
 
         activeTaskIds.add(miscTask.getTaskId());
@@ -1816,15 +1812,27 @@ private void fillDecorativeSlots(int[] slots, Material material) {
      */
     @Override
     public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
-        if (reason == ExitReason.KICKED) {
+        Double pendingDeposit = pendingOnlineDeposits.get(terminatedPlayerId);
+        boolean knownPayoutPending = pendingDeposit != null && pendingDeposit > 0;
+        switch (GameTerminationPolicy.roulette(reason, knownPayoutPending)) {
+        case FORFEIT:
+            pendingOnlineDeposits.remove(terminatedPlayerId);
             forfeitBet(terminatedPlayerId);
-        } else if (reason == ExitReason.PLUGIN_DISABLE) {
-            Double pendingDeposit = pendingOnlineDeposits.remove(terminatedPlayerId);
-            if (pendingDeposit != null && pendingDeposit > 0) {
-                queueShutdownWinPayout(terminatedPlayerId, pendingDeposit);
-            } else {
-                refundForShutdown(terminatedPlayerId);
-            }
+            break;
+        case QUEUE_KNOWN_PAYOUT:
+            pendingOnlineDeposits.remove(terminatedPlayerId);
+            queueKnownWinPayout(terminatedPlayerId, pendingDeposit, reason);
+            finalizeRoundResolution(terminatedPlayerId);
+            break;
+        case REFUND:
+            pendingOnlineDeposits.remove(terminatedPlayerId);
+            refundForShutdown(terminatedPlayerId);
+            break;
+        case RIDE_TO_RESULT:
+        case NO_ACTION:
+            break;
+        default:
+            throw new IllegalStateException("Unexpected Roulette termination action");
         }
     }
 
@@ -1841,9 +1849,12 @@ private void fillDecorativeSlots(int[] slots, Material material) {
         pendingOnlineDeposits.put(playerId, amount);
     }
 
-    /** Called once the deposit above actually completes. */
-    void clearOnlineDepositPending(UUID playerId) {
-        pendingOnlineDeposits.remove(playerId);
+    /**
+     * Claims the delayed live deposit. If termination persisted it first,
+     * the old scheduled task becomes a no-op rather than paying twice.
+     */
+    boolean claimOnlineDeposit(UUID playerId, double amount) {
+        return pendingOnlineDeposits.remove(playerId, amount);
     }
 
     /**
@@ -1852,7 +1863,7 @@ private void fillDecorativeSlots(int[] slots, Material material) {
      * refundForShutdown's persistence, but for a known payout amount
      * rather than a re-derived stake total.
      */
-    private void queueShutdownWinPayout(UUID playerId, double amount) {
+    private void queueKnownWinPayout(UUID playerId, double amount, ExitReason reason) {
         Material currencyMaterial = plugin.getCurrency(internalName);
         PendingPayout payout = PendingPayout.create(
             playerId,
@@ -1862,7 +1873,9 @@ private void fillDecorativeSlots(int[] slots, Material material) {
             currencyMaterial != null ? currencyMaterial.name() : null,
             currencyName,
             amount,
-            PayoutMessages.serverRestartRefundContext("Roulette")
+            reason == ExitReason.PLUGIN_DISABLE
+                ? "The server restarted after your Roulette result was determined. Your payout was saved."
+                : PayoutMessages.disconnectedMidGameContext("Roulette")
         );
         boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
         if (!persisted) {
@@ -1940,4 +1953,3 @@ private void fillDecorativeSlots(int[] slots, Material material) {
     }
 }
 
-   

--- a/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
@@ -36,18 +36,20 @@ import org.nc.nccasino.entities.Dealer;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.objects.Pair;
 import org.nc.nccasino.helpers.Preferences;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+import org.nc.nccasino.session.TerminableSession;
 
-public class RouletteInventory extends DealerInventory {
+public class RouletteInventory extends DealerInventory implements TerminableSession {
     private final MultiChannelEngine mce;
     private final List<Integer> wheelLayout = Arrays.asList(
-        0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23, 10, 5, 
+        0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23, 10, 5,
         24, 16, 33, 1, 20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26
     );
-    private final Set<Player> switchingPlayers = new HashSet<>();
+    private final Set<UUID> switchingPlayers = new HashSet<>();
     private final Nccasino plugin;
     private final Map<UUID, Stack<Pair<String, Integer>>> Bets;
-    public final Map<Player, BettingTable> Tables;
-    private Map<Player, Integer> activeAnimations;
+    public final Map<UUID, BettingTable> Tables;
     private int frameCounter;
     private int bettingCountdownTaskId = -1;
     private boolean betsClosed = false;
@@ -132,7 +134,6 @@ public class RouletteInventory extends DealerInventory {
         this.plugin = plugin;
         this.Bets = new HashMap<>();
         this.Tables = new HashMap<>();
-        this.activeAnimations = new HashMap<>();
         this.internalName = internalName;
         this.currencyMode = plugin.getCurrencyMode(internalName);
         this.currencyName = plugin.getCurrencyName(internalName);
@@ -280,8 +281,7 @@ public class RouletteInventory extends DealerInventory {
         Bets.clear();
         Tables.clear();
         playersWithBets.clear();
-        newtry.clear(); 
-        activeAnimations.clear();
+        newtry.clear();
         unregisterListener();
         
     }
@@ -295,7 +295,7 @@ public class RouletteInventory extends DealerInventory {
             if (player.getInventory() != null) {
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     if (player != null&&player.isOnline()) {
-                        if (!BettingTable.switchingPlayers.contains(player)){
+                        if (!BettingTable.switchingPlayers.contains(player.getUniqueId())){
                         switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
                             case STANDARD:{
                                 break;}
@@ -329,14 +329,14 @@ public class RouletteInventory extends DealerInventory {
 
     @EventHandler
     public void handlePlayerQuit(PlayerQuitEvent event) {
-        switchingPlayers.remove(event.getPlayer());
+        switchingPlayers.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler
     public void handleInventoryClose(InventoryCloseEvent event) {
         Player player = (Player) event.getPlayer();
         // Check if the player is switching inventories
-        if (switchingPlayers.contains(player)) {
+        if (switchingPlayers.contains(player.getUniqueId())) {
             return; // Ignore this close event if the player is switching
         }
     
@@ -463,7 +463,7 @@ private void handleGameMenuClick(int slot, Player player) {
 }
 
 private void openBettingTable(Player player) {
-    switchingPlayers.add(player); // Mark the player as switching inventories
+    switchingPlayers.add(player.getUniqueId()); // Mark the player as switching inventories
 
     Bukkit.getScheduler().runTaskLater(plugin, () -> {
         Mob dealer = Dealer.findDealer(dealerId, player.getLocation());
@@ -471,9 +471,9 @@ private void openBettingTable(Player player) {
             Stack<Pair<String, Integer>> bets = getPlayerBets(player.getUniqueId());
             String internalName = Dealer.getInternalName(dealer);
             BettingTable bettingTable = new BettingTable(player, dealer, plugin, bets, internalName, this, globalCountdown);
-            Tables.put(player, bettingTable);
+            Tables.put(player.getUniqueId(), bettingTable);
             player.openInventory(bettingTable.getInventory());
-             if (SoundHelper.getSoundSafely("item.book.page_turn", player) != null)player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, SoundCategory.MASTER, 5.0f, 1.0f); 
+             if (SoundHelper.getSoundSafely("item.book.page_turn", player) != null)player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, SoundCategory.MASTER, 5.0f, 1.0f);
              if (plugin.getPreferences(player.getUniqueId()).getSoundSetting() == Preferences.SoundSetting.ON) {
             mce.addPlayerToChannel("BettingTable", player);
             mce.removePlayerFromChannel("RouletteWheel", player);}
@@ -481,25 +481,27 @@ private void openBettingTable(Player player) {
                 case STANDARD:{
                     break;}
                 case VERBOSE:{
-                    player.sendMessage("§aOpened betting table.");            break;     
+                    player.sendMessage("§aOpened betting table.");            break;
                 }
                     case NONE:{
                     break;
                 }
-            } 
+            }
         } else {
             player.sendMessage("§cError: Dealer not found. Unable to open betting table.");
              if (SoundHelper.getSoundSafely("entity.villager.no", player) != null)player.playSound(player.getLocation(), Sound.ENTITY_VILLAGER_NO, SoundCategory.MASTER, 1.0f, 1.0f);
         }
-        switchingPlayers.remove(player); // Remove the flag after the switch
+        switchingPlayers.remove(player.getUniqueId()); // Remove the flag after the switch
     }, 1L); // Small delay to allow the inventory to switch
 }
 
 
 private void exitGame(Player player) {
-    BettingTable bt = Tables.get(player);
+    UUID playerId = player.getUniqueId();
+    BettingTable bt = Tables.remove(playerId);
     if (bt != null) {
         bt.clearAllBetsAndRefund(player);
+        bt.cleanupListener();
     }
     player.closeInventory();
     switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
@@ -507,14 +509,16 @@ private void exitGame(Player player) {
             break;}
         case VERBOSE:{
     player.sendMessage("§cYou have left the game.");
-    break;     
+    break;
         }
             case NONE:{
             break;
         }
-    } 
-    Tables.remove(player);
-    removeAllBets(player.getUniqueId());
+    }
+    removeAllBets(playerId);
+    newtry.remove(playerId);
+    playersWithBets.remove(playerId);
+    SessionRegistry.unregister(playerId, this);
 
     if (Tables.isEmpty()) {
         resetToStartState();
@@ -592,7 +596,7 @@ private void exitGame(Player player) {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public Map<UUID,Stack<Pair<String, Integer>>> newtry=new HashMap();
-    private List<Player> playersWithBets = new ArrayList<>();
+    private List<UUID> playersWithBets = new ArrayList<>();
 
     @SuppressWarnings("unchecked")
     private void handleBetClosure() {
@@ -600,56 +604,68 @@ private void exitGame(Player player) {
         betsClosed = true;
         List<Player> activePlayers = new ArrayList<>();
         playersWithBets.clear();
-        //List<Player> playersWithBets = new ArrayList<>();
 
         for (Player player : Bukkit.getServer().getOnlinePlayers()) {
-            if (player == null) 
+            if (player == null)
                 continue;
             InventoryView openInventory = player.getOpenInventory();
             if (openInventory != null && openInventory.getTopInventory().getHolder() == this) {
                 activePlayers.add(player);
             }
         }
-      
-        for (Player player : Tables.keySet()) {
-            InventoryView openInventory = player.getOpenInventory();
-            if (openInventory != null && (openInventory.getTopInventory().getHolder() == this || openInventory.getTopInventory().getHolder() == Tables.get(player))) {
-                activePlayers.add(player);
+
+        // Snapshot every player with a committed bet into this round's
+        // resolution list, regardless of whether they're online right now.
+        // The spin resolves independently of player presence, so a bet
+        // already withdrawn from a player's balance must ride the spin to
+        // a real outcome (delivered as a pending payout if they're gone by
+        // the time it resolves) rather than being silently excluded and
+        // stranded here just because they happened to be offline at this
+        // exact tick.
+        for (UUID playerId : Tables.keySet()) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                InventoryView openInventory = player.getOpenInventory();
+                if (openInventory != null && (openInventory.getTopInventory().getHolder() == this || openInventory.getTopInventory().getHolder() == Tables.get(playerId))) {
+                    if (!activePlayers.contains(player)) {
+                        activePlayers.add(player);
+                    }
+                }
             }
 
-            if (player != null && player.isOnline()) {
-                Stack<Pair<String, Integer>> playerBets = getPlayerBets(player.getUniqueId());
-                if (!playerBets.isEmpty()) {
-                    newtry.put(player.getUniqueId(), (Stack<Pair<String, Integer>>) playerBets.clone());
+            Stack<Pair<String, Integer>> playerBets = getPlayerBets(playerId);
+            if (!playerBets.isEmpty()) {
+                newtry.put(playerId, (Stack<Pair<String, Integer>>) playerBets.clone());
+                if (player != null && !activePlayers.contains(player)) {
                     activePlayers.add(player);
-                    playersWithBets.add(player);
-                    Bets.put(player.getUniqueId(), playerBets);
                 }
-                
+                playersWithBets.add(playerId);
+                Bets.put(playerId, playerBets);
             }
         }
 
         if (playersWithBets.isEmpty() && activePlayers.isEmpty()) {
             resetToStartState();
         } else {
-            
-            for (Player player : playersWithBets) {
-                if (player.isOnline()) {
-                    switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
+
+            for (UUID playerId : playersWithBets) {
+                Player player = Bukkit.getPlayer(playerId);
+                if (player != null) {
+                    switch(plugin.getPreferences(playerId).getMessageSetting()){
                         case STANDARD:{
                             break;}
                         case VERBOSE:{
                             player.sendMessage("§dBets locked, spinning!");
-                            break;     
+                            break;
                         }
                             case NONE:{
                             break;
                         }
-                    } 
+                    }
                 }
             }
 
-            miscTask=Bukkit.getScheduler().runTaskLater(plugin, () -> 
+            miscTask=Bukkit.getScheduler().runTaskLater(plugin, () ->
             mce.playSong("RouletteWheel", RouletteSongs.getBallLaunch(), false, "Ball Launch")
             , 20L);
             activeTaskIds.add(miscTask.getTaskId()); // Store the task ID
@@ -1218,71 +1234,77 @@ private void handleWinningNumber() {
     finalpicked = true;
 
     mce.playSong("RouletteWheel", RouletteSongs.getFinalSpot(), false, "Final spot");
-    // Loop over players who have placed bets
-    for (Player player : playersWithBets) {
-        if (player.isOnline()) {
-            // Schedule the processing to run after a delay
-            miscTask=Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                BettingTable bettingTable = Tables.get(player);
-                if (bettingTable != null) {
-                    // Get the bet stack directly from the BettingTable
-                    Stack<Pair<String, Integer>> playerBets =newtry.get(player.getUniqueId());
-  
-                    if (!playerBets.isEmpty()) {
-                        // Notify the player of the winning number
-                        if (isRed(winningNumber)) {
-                            switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-                                case STANDARD:{
-                                    player.sendMessage("§cHit Red " + winningNumber + "!");
-                                    break;}
-                                case VERBOSE:{
-                                    player.sendMessage("§cHit Red " + winningNumber + "!");
-                                    break;     
-                                }
-                                    case NONE:{
-                                    break;
-                                }
-                            } 
-                        } else if (isBlack(winningNumber)) {
-                            switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-                                case STANDARD:{
-                                    player.sendMessage("§fHit Black " + winningNumber + "!");
-                                    break;}
-                                case VERBOSE:{
-                                    player.sendMessage("§fHit Black " + winningNumber + "!");
-                                    break;     
-                                }
-                                    case NONE:{
-                                    break;
-                                }
-                            } 
-                        } else {
-                            switch(plugin.getPreferences(player.getUniqueId()).getMessageSetting()){
-                                case STANDARD:{
-                                    player.sendMessage("§aHit Green " + winningNumber + ", WOW!");
-                                    break;}
-                                case VERBOSE:{
-                                    player.sendMessage("§aHit Green " + winningNumber + ", WOW!");
-                                    break;     
-                                }
-                                    case NONE:{
-                                    break;
-                                }
-                            } 
-                        }
+    // Loop over players who have placed bets. Scheduled and resolved by
+    // UUID regardless of current online status — the bet already rode the
+    // spin, so it's owed a real outcome either way (processSpinResult
+    // itself decides direct credit vs. a durable pending payout based on
+    // whether the player is back online by the time this runs).
+    for (UUID playerId : playersWithBets) {
+        // Schedule the processing to run after a delay
+        miscTask=Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            BettingTable bettingTable = Tables.get(playerId);
+            if (bettingTable == null) {
+                plugin.getLogger().warning("No betting table found for player: " + playerId);
+                return;
+            }
 
-                        // Process the bets
-                        bettingTable.processSpinResult(winningNumber, playerBets);
-                    } else {
-                        plugin.getLogger().warning(player.getName() + " has no bets to process.");
+            // Get the bet stack directly from the BettingTable
+            Stack<Pair<String, Integer>> playerBets = newtry.get(playerId);
+            if (playerBets == null || playerBets.isEmpty()) {
+                plugin.getLogger().warning(playerId + " has no bets to process.");
+                return;
+            }
+
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null) {
+                // Notify the player of the winning number
+                if (isRed(winningNumber)) {
+                    switch(plugin.getPreferences(playerId).getMessageSetting()){
+                        case STANDARD:{
+                            player.sendMessage("§cHit Red " + winningNumber + "!");
+                            break;}
+                        case VERBOSE:{
+                            player.sendMessage("§cHit Red " + winningNumber + "!");
+                            break;
+                        }
+                            case NONE:{
+                            break;
+                        }
+                    }
+                } else if (isBlack(winningNumber)) {
+                    switch(plugin.getPreferences(playerId).getMessageSetting()){
+                        case STANDARD:{
+                            player.sendMessage("§fHit Black " + winningNumber + "!");
+                            break;}
+                        case VERBOSE:{
+                            player.sendMessage("§fHit Black " + winningNumber + "!");
+                            break;
+                        }
+                            case NONE:{
+                            break;
+                        }
                     }
                 } else {
-                    plugin.getLogger().warning("No betting table found for player: " + player.getName());
+                    switch(plugin.getPreferences(playerId).getMessageSetting()){
+                        case STANDARD:{
+                            player.sendMessage("§aHit Green " + winningNumber + ", WOW!");
+                            break;}
+                        case VERBOSE:{
+                            player.sendMessage("§aHit Green " + winningNumber + ", WOW!");
+                            break;
+                        }
+                            case NONE:{
+                            break;
+                        }
+                    }
                 }
-            }, 30L);
-            
-            activeTaskIds.add(miscTask.getTaskId()); 
-        }
+            }
+
+            // Process the bets
+            bettingTable.processSpinResult(winningNumber, playerBets);
+        }, 30L);
+
+        activeTaskIds.add(miscTask.getTaskId());
     }
 
     // Reset for the next round
@@ -1764,6 +1786,59 @@ private void fillDecorativeSlots(int[] slots, Material material) {
             bets = new Stack<>();
         }
         Bets.put(playerId, bets);
+        if (!bets.isEmpty()) {
+            // A committed, currency-withdrawn bet exists for this player —
+            // make sure a kick can reach us to forfeit it even if they
+            // aren't actively viewing any Roulette inventory right now.
+            SessionRegistry.register(playerId, this);
+        }
+    }
+
+    /**
+     * Kicked players forfeit unconditionally, regardless of round phase —
+     * no refund, no cash-out, no pending payout. Reached via
+     * SessionRegistry from the central PlayerQuitEvent/PlayerKickEvent
+     * handling; a plain disconnect intentionally does nothing here and
+     * falls through to normal resolution (see handleBetClosure/
+     * handleWinningNumber), since the spin resolves independently of
+     * player presence.
+     */
+    @Override
+    public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
+        if (reason == ExitReason.KICKED) {
+            forfeitBet(terminatedPlayerId);
+        }
+    }
+
+    private void forfeitBet(UUID playerId) {
+        Bets.remove(playerId);
+        newtry.remove(playerId);
+        playersWithBets.remove(playerId);
+
+        BettingTable bt = Tables.remove(playerId);
+        if (bt != null) {
+            bt.cleanupListener();
+        }
+    }
+
+    /**
+     * Final cleanup once a player's bet for this round has been fully
+     * resolved (paid directly or queued as a pending payout) — called from
+     * BettingTable.processSpinResult. Avoids leaking the BettingTable's
+     * registered listener and Tables entry indefinitely, which previously
+     * only ever happened via the manual "Exit" button.
+     */
+    void finalizeRoundResolution(UUID playerId) {
+        Bets.remove(playerId);
+        newtry.remove(playerId);
+        playersWithBets.remove(playerId);
+
+        BettingTable bt = Tables.remove(playerId);
+        if (bt != null) {
+            bt.cleanupListener();
+        }
+
+        SessionRegistry.unregister(playerId, this);
     }
 }
 

--- a/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
@@ -36,6 +36,8 @@ import org.nc.nccasino.entities.Dealer;
 import org.nc.nccasino.helpers.SoundHelper;
 import org.nc.nccasino.objects.Pair;
 import org.nc.nccasino.helpers.Preferences;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
 import org.nc.nccasino.session.ExitReason;
 import org.nc.nccasino.session.SessionRegistry;
 import org.nc.nccasino.session.TerminableSession;
@@ -1801,12 +1803,55 @@ private void fillDecorativeSlots(int[] slots, Material material) {
      * handling; a plain disconnect intentionally does nothing here and
      * falls through to normal resolution (see handleBetClosure/
      * handleWinningNumber), since the spin resolves independently of
-     * player presence.
+     * player presence. A plugin/server shutdown is different again: the
+     * scheduled tasks that would normally carry the bet through to that
+     * same resolution are about to be cancelled along with everything
+     * else, so there's no "riding it out" — refund instead.
      */
     @Override
     public void onSessionTerminated(UUID terminatedPlayerId, ExitReason reason) {
         if (reason == ExitReason.KICKED) {
             forfeitBet(terminatedPlayerId);
+        } else if (reason == ExitReason.PLUGIN_DISABLE) {
+            refundForShutdown(terminatedPlayerId);
+        }
+    }
+
+    /**
+     * The server is shutting down with this player's bet still committed
+     * to an in-flight round. Refunds the full wagered amount via the
+     * durable pending-payout store (delivered as a normal chat message on
+     * next join) rather than a live credit, since this player may not
+     * even be online right now.
+     */
+    private void refundForShutdown(UUID playerId) {
+        Stack<Pair<String, Integer>> bets = Bets.get(playerId);
+        if (bets == null || bets.isEmpty()) {
+            return;
+        }
+
+        double total = 0;
+        for (Pair<String, Integer> bet : bets) {
+            total += bet.getSecond();
+        }
+        if (total <= 0) {
+            return;
+        }
+
+        Material currencyMaterial = plugin.getCurrency(internalName);
+        PendingPayout payout = PendingPayout.create(
+            playerId,
+            "Roulette",
+            internalName,
+            currencyMode,
+            currencyMaterial != null ? currencyMaterial.name() : null,
+            currencyName,
+            total,
+            PayoutMessages.serverRestartRefundContext("Roulette")
+        );
+        boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
+        if (!persisted) {
+            plugin.getLogger().warning("[NCCasino] Roulette shutdown refund failed to persist for " + playerId + ".");
         }
     }
 

--- a/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
+++ b/src/main/java/org/nc/nccasino/games/Roulette/RouletteInventory.java
@@ -52,6 +52,12 @@ public class RouletteInventory extends DealerInventory implements TerminableSess
     private final Nccasino plugin;
     private final Map<UUID, Stack<Pair<String, Integer>>> Bets;
     public final Map<UUID, BettingTable> Tables;
+    // Tracks a spin's already-computed winning payout for the ~1s window
+    // between it being scheduled and the deposit task actually running.
+    // Lets onSessionTerminated tell "a win is in flight, pay this exact
+    // amount" apart from "no resolution has happened yet, refund the
+    // stake from Bets" on a plugin/server shutdown.
+    private final Map<UUID, Double> pendingOnlineDeposits = new HashMap<>();
     private int frameCounter;
     private int bettingCountdownTaskId = -1;
     private boolean betsClosed = false;
@@ -1813,7 +1819,54 @@ private void fillDecorativeSlots(int[] slots, Material material) {
         if (reason == ExitReason.KICKED) {
             forfeitBet(terminatedPlayerId);
         } else if (reason == ExitReason.PLUGIN_DISABLE) {
-            refundForShutdown(terminatedPlayerId);
+            Double pendingDeposit = pendingOnlineDeposits.remove(terminatedPlayerId);
+            if (pendingDeposit != null && pendingDeposit > 0) {
+                queueShutdownWinPayout(terminatedPlayerId, pendingDeposit);
+            } else {
+                refundForShutdown(terminatedPlayerId);
+            }
+        }
+    }
+
+    /**
+     * Called by BettingTable right after a spin resolves to a win for an
+     * online player, before the deposit that pays it is scheduled. Marks
+     * the exact amount owed so a shutdown landing before that deposit runs
+     * queues the correct payout instead of losing it (the deposit task
+     * itself is about to be cancelled along with everything else) or
+     * falling back to refundForShutdown's stake-based amount, which would
+     * short a winner down to just their wager back.
+     */
+    void markOnlineDepositPending(UUID playerId, double amount) {
+        pendingOnlineDeposits.put(playerId, amount);
+    }
+
+    /** Called once the deposit above actually completes. */
+    void clearOnlineDepositPending(UUID playerId) {
+        pendingOnlineDeposits.remove(playerId);
+    }
+
+    /**
+     * Durably queues an already-resolved winning payout that a shutdown
+     * interrupted before its scheduled deposit could run. Mirrors
+     * refundForShutdown's persistence, but for a known payout amount
+     * rather than a re-derived stake total.
+     */
+    private void queueShutdownWinPayout(UUID playerId, double amount) {
+        Material currencyMaterial = plugin.getCurrency(internalName);
+        PendingPayout payout = PendingPayout.create(
+            playerId,
+            "Roulette",
+            internalName,
+            currencyMode,
+            currencyMaterial != null ? currencyMaterial.name() : null,
+            currencyName,
+            amount,
+            PayoutMessages.serverRestartRefundContext("Roulette")
+        );
+        boolean persisted = plugin.getPendingPayoutStore().addPendingPayout(payout);
+        if (!persisted) {
+            plugin.getLogger().warning("[NCCasino] Roulette shutdown win payout failed to persist for " + playerId + ".");
         }
     }
 

--- a/src/main/java/org/nc/nccasino/listeners/DealerInteractListener.java
+++ b/src/main/java/org/nc/nccasino/listeners/DealerInteractListener.java
@@ -44,6 +44,18 @@ public class DealerInteractListener implements Listener {
         this.plugin = plugin;
     }
 
+    /**
+     * Removes {@code player} from the active-intro-animation tracker. Used
+     * on disconnect: the natural-completion removal path in
+     * {@code afterAnimationComplete} only runs if the player is still
+     * online, so a disconnect mid-animation could otherwise leave them
+     * permanently marked as "already saw the animation," suppressing it
+     * forever on future dealer interactions.
+     */
+    public static void clearActiveAnimation(Player player) {
+        activeAnimations.remove(player);
+    }
+
     private Mob findDealerFromJockey(Mob clickedMob) {
         // First check if this mob is a dealer
         if (Dealer.isDealer(clickedMob)) {

--- a/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
+++ b/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
@@ -1,12 +1,18 @@
 package org.nc.nccasino.listeners;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.nc.nccasino.Nccasino;
+import org.nc.nccasino.payout.DeliveryResult;
+import org.nc.nccasino.payout.PayoutMessages;
+import org.nc.nccasino.payout.PendingPayout;
+import org.nc.nccasino.payout.PendingPayoutStore;
 import org.nc.nccasino.session.ExitReason;
 import org.nc.nccasino.session.SessionRegistry;
 
@@ -25,6 +31,13 @@ import java.util.UUID;
  * chance to cancel it) to classify the quit that follows it as
  * {@link ExitReason#KICKED} instead — it does not run a separate cleanup
  * path of its own.
+ *
+ * <p>{@code PlayerJoinEvent} settles whatever pending payouts/results
+ * accumulated while the player was away. It deliberately does not attempt
+ * to resume an interrupted game, clear admin edit-mode state, or repair
+ * stale cached session objects — those are separate, later concerns
+ * (respectively: not requested, admin edit-mode cleanup, and stale-client
+ * handling).
  */
 public class PlayerSessionListener implements Listener {
 
@@ -58,5 +71,23 @@ public class PlayerSessionListener implements Listener {
         UUID playerId = event.getPlayer().getUniqueId();
         ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
         SessionRegistry.terminatePlayerSession(playerId, reason);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        PendingPayoutStore store = plugin.getPendingPayoutStore();
+        if (store == null) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        DeliveryResult result = store.attemptDeliver(player);
+
+        for (PendingPayout payout : result.delivered()) {
+            player.sendMessage(PayoutMessages.formatDelivered(payout));
+        }
+        if (!result.stillPending().isEmpty()) {
+            player.sendMessage(PayoutMessages.formatPendingRetryNotice(result.stillPending().size()));
+        }
     }
 }

--- a/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
+++ b/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
@@ -1,0 +1,62 @@
+package org.nc.nccasino.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.nc.nccasino.Nccasino;
+import org.nc.nccasino.session.ExitReason;
+import org.nc.nccasino.session.SessionRegistry;
+
+import java.util.UUID;
+
+/**
+ * The single source of "this player is gone" for gameplay purposes.
+ *
+ * <p>{@code PlayerQuitEvent} is the primary, guaranteed-to-fire disconnect
+ * signal — NCCasino cannot and does not try to distinguish voluntary
+ * disconnect, client crash, Wi-Fi loss, timeout, or a Geyser/Bedrock drop;
+ * all of them surface here identically as {@link ExitReason#DISCONNECTED}.
+ *
+ * <p>{@code PlayerKickEvent} is observed only (at {@link EventPriority#MONITOR}, so
+ * it sees the final cancellation state after every other plugin has had a
+ * chance to cancel it) to classify the quit that follows it as
+ * {@link ExitReason#KICKED} instead — it does not run a separate cleanup
+ * path of its own.
+ */
+public class PlayerSessionListener implements Listener {
+
+    private final Nccasino plugin;
+
+    public PlayerSessionListener(Nccasino plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerKick(PlayerKickEvent event) {
+        if (event.isCancelled()) {
+            // Player stays connected; nothing to classify.
+            return;
+        }
+
+        UUID playerId = event.getPlayer().getUniqueId();
+        SessionRegistry.markKicked(playerId);
+
+        // Safety net: a non-cancelled kick is always followed by a quit in
+        // the same disconnect sequence, but guard against the marker
+        // outliving that window and misclassifying a later, unrelated
+        // disconnect as a kick — which would wrongly deny that player a
+        // refund they are entitled to.
+        Bukkit.getScheduler().runTaskLater(plugin,
+            () -> SessionRegistry.clearKickMarker(playerId), 5L);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        UUID playerId = event.getPlayer().getUniqueId();
+        ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
+        SessionRegistry.terminatePlayerSession(playerId, reason);
+    }
+}

--- a/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
+++ b/src/main/java/org/nc/nccasino/listeners/PlayerSessionListener.java
@@ -9,6 +9,13 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.nc.nccasino.Nccasino;
+import org.nc.nccasino.components.AdminMenu;
+import org.nc.nccasino.components.BaccaratMenu;
+import org.nc.nccasino.components.BlackjackMenu;
+import org.nc.nccasino.components.CoinFlipMenu;
+import org.nc.nccasino.components.DragonDescentMenu;
+import org.nc.nccasino.components.MinesMenu;
+import org.nc.nccasino.components.RouletteMenu;
 import org.nc.nccasino.payout.DeliveryResult;
 import org.nc.nccasino.payout.PayoutMessages;
 import org.nc.nccasino.payout.PendingPayout;
@@ -32,12 +39,15 @@ import java.util.UUID;
  * {@link ExitReason#KICKED} instead — it does not run a separate cleanup
  * path of its own.
  *
+ * <p>Every quit or kick also unconditionally releases any admin edit-mode
+ * lock and stale intro-animation tracking for that player, regardless of
+ * {@link ExitReason} — this is a UI-lock release, not wager compensation,
+ * so it must not be gated the way payout policy is.
+ *
  * <p>{@code PlayerJoinEvent} settles whatever pending payouts/results
  * accumulated while the player was away. It deliberately does not attempt
- * to resume an interrupted game, clear admin edit-mode state, or repair
- * stale cached session objects — those are separate, later concerns
- * (respectively: not requested, admin edit-mode cleanup, and stale-client
- * handling).
+ * to resume an interrupted game or repair stale cached session objects —
+ * the latter is a separate, later concern (stale-client handling).
  */
 public class PlayerSessionListener implements Listener {
 
@@ -71,6 +81,31 @@ public class PlayerSessionListener implements Listener {
         UUID playerId = event.getPlayer().getUniqueId();
         ExitReason reason = SessionRegistry.consumeQuitReason(playerId);
         SessionRegistry.terminatePlayerSession(playerId, reason);
+
+        // Admin edit-mode/occupation cleanup runs unconditionally, on every
+        // quit or kick alike: it's about releasing a UI lock, not wager
+        // compensation, so it must not depend on ExitReason.
+        clearAdminAndInteractionState(event.getPlayer(), playerId);
+    }
+
+    /**
+     * Central cleanup for the admin edit-mode/settings-menu stale-lock bug:
+     * a player who starts editing something (e.g. clicks "Edit Timer",
+     * which closes the menu and waits for a chat reply) and then
+     * disconnects before finishing was previously locked out of every
+     * NCCasino dealer forever, since nothing but successful chat
+     * submission or an open inventory closing ever cleared these maps.
+     * Also clears stale intro-animation tracking for the same reason.
+     */
+    private void clearAdminAndInteractionState(Player player, UUID playerId) {
+        AdminMenu.clearPlayerEditState(playerId);
+        BlackjackMenu.clearPlayerState(playerId);
+        RouletteMenu.clearPlayerState(playerId);
+        MinesMenu.clearPlayerState(playerId);
+        BaccaratMenu.clearPlayerState(playerId);
+        CoinFlipMenu.clearPlayerState(playerId);
+        DragonDescentMenu.clearPlayerState(playerId);
+        DealerInteractListener.clearActiveAnimation(player);
     }
 
     @EventHandler

--- a/src/main/java/org/nc/nccasino/payout/DeliveryResult.java
+++ b/src/main/java/org/nc/nccasino/payout/DeliveryResult.java
@@ -1,0 +1,15 @@
+package org.nc.nccasino.payout;
+
+import java.util.List;
+
+/**
+ * Summarizes what happened when {@link PendingPayoutStore#attemptDeliver}
+ * tried to settle every pending record for a player, so the caller (join
+ * handling) can build appropriate messages without re-deriving state.
+ */
+public record DeliveryResult(List<PendingPayout> delivered, List<PendingPayout> stillPending) {
+
+    public boolean isEmpty() {
+        return delivered.isEmpty() && stillPending.isEmpty();
+    }
+}

--- a/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
+++ b/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
@@ -2,6 +2,7 @@ package org.nc.nccasino.payout;
 
 import org.bukkit.ChatColor;
 import org.nc.nccasino.currency.CurrencyMode;
+import org.nc.nccasino.currency.MoneyHelper;
 
 /**
  * Centralizes player-facing pending-payout/result text in one place so it
@@ -47,10 +48,10 @@ public final class PayoutMessages {
     }
 
     private static String formatAmount(PendingPayout payout) {
-        int whole = (int) payout.amount();
         if (payout.currencyMode() == CurrencyMode.VAULT) {
-            return "$" + whole;
+            return "$" + MoneyHelper.roundDisplay(MoneyHelper.bd(payout.amount())).toPlainString();
         }
+        int whole = (int) payout.amount();
         String name = payout.currencyName() != null && !payout.currencyName().isBlank()
             ? payout.currencyName().toLowerCase()
             : "currency";

--- a/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
+++ b/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
@@ -23,6 +23,17 @@ public final class PayoutMessages {
             + " game. The game finished while you were offline.";
     }
 
+    /**
+     * The context line stored on a pending record created because the
+     * server shut down while a round was still in flight — the game
+     * couldn't be resolved to a real outcome, so the wager is refunded
+     * rather than played out.
+     */
+    public static String serverRestartRefundContext(String gameType) {
+        return "The server restarted while your " + gameType
+            + " bet was still awaiting resolution, so it has been refunded.";
+    }
+
     /** The chat message shown when a pending payout/result is delivered on join. */
     public static String formatDelivered(PendingPayout payout) {
         return ChatColor.YELLOW + payout.context()

--- a/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
+++ b/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
@@ -1,0 +1,42 @@
+package org.nc.nccasino.payout;
+
+import org.bukkit.ChatColor;
+import org.nc.nccasino.currency.CurrencyMode;
+
+/**
+ * Centralizes player-facing pending-payout/result text in one place so it
+ * stays consistent and is easy to localize later. This is not a
+ * localization system — just a single home for these strings for now.
+ */
+public final class PayoutMessages {
+
+    private PayoutMessages() {
+    }
+
+    /**
+     * The standard context line stored on a pending record created because
+     * a player disconnected mid-game, e.g. "You disconnected during an
+     * active Roulette game. The game finished while you were offline."
+     */
+    public static String disconnectedMidGameContext(String gameType) {
+        return "You disconnected during an active " + gameType
+            + " game. The game finished while you were offline.";
+    }
+
+    /** The chat message shown when a pending payout/result is delivered on join. */
+    public static String formatDelivered(PendingPayout payout) {
+        return ChatColor.YELLOW + payout.context()
+            + "\n" + ChatColor.GREEN + "Payout: " + formatAmount(payout);
+    }
+
+    private static String formatAmount(PendingPayout payout) {
+        int whole = (int) payout.amount();
+        if (payout.currencyMode() == CurrencyMode.VAULT) {
+            return "$" + whole;
+        }
+        String name = payout.currencyName() != null && !payout.currencyName().isBlank()
+            ? payout.currencyName().toLowerCase()
+            : "currency";
+        return whole + " " + name + (whole != 1 ? "s" : "");
+    }
+}

--- a/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
+++ b/src/main/java/org/nc/nccasino/payout/PayoutMessages.java
@@ -29,6 +29,12 @@ public final class PayoutMessages {
             + "\n" + ChatColor.GREEN + "Payout: " + formatAmount(payout);
     }
 
+    /** Shown on join when one or more pending payouts exist but couldn't be delivered yet. */
+    public static String formatPendingRetryNotice(int count) {
+        return ChatColor.GOLD + "You have " + count + " pending payout" + (count == 1 ? "" : "s")
+            + " that could not be delivered yet. It will be delivered automatically once possible.";
+    }
+
     private static String formatAmount(PendingPayout payout) {
         int whole = (int) payout.amount();
         if (payout.currencyMode() == CurrencyMode.VAULT) {

--- a/src/main/java/org/nc/nccasino/payout/PendingPayout.java
+++ b/src/main/java/org/nc/nccasino/payout/PendingPayout.java
@@ -1,0 +1,61 @@
+package org.nc.nccasino.payout;
+
+import org.nc.nccasino.currency.CurrencyMode;
+
+import java.util.UUID;
+
+/**
+ * A durable record of money (or just an outcome message) owed to a player
+ * because a game finished while they were offline. Immutable — presence in
+ * {@link PendingPayoutStore} means "still pending"; once delivered, the
+ * record is removed rather than mutated.
+ *
+ * <p>{@code amount() <= 0} is a valid, expected case: a loss still gets a
+ * record so the player receives a "here's what happened" message on
+ * reconnect, without needing a separate data structure for pure-message
+ * results.
+ *
+ * <p>Currency identity ({@code currencyMode}, {@code currencyMaterial},
+ * {@code currencyName}) is snapshotted at creation time rather than
+ * re-resolved from the originating dealer at delivery time, since the
+ * dealer's config can change — or the dealer can be deleted entirely —
+ * between when a disconnected player's outcome is calculated and when they
+ * reconnect, possibly after a server restart.
+ */
+public record PendingPayout(
+    UUID id,
+    UUID playerId,
+    String gameType,
+    String dealerInternalName,
+    CurrencyMode currencyMode,
+    String currencyMaterial,
+    String currencyName,
+    double amount,
+    long createdAtEpochMillis,
+    String context
+) {
+
+    public static PendingPayout create(
+        UUID playerId,
+        String gameType,
+        String dealerInternalName,
+        CurrencyMode currencyMode,
+        String currencyMaterial,
+        String currencyName,
+        double amount,
+        String context
+    ) {
+        return new PendingPayout(
+            UUID.randomUUID(),
+            playerId,
+            gameType,
+            dealerInternalName,
+            currencyMode,
+            currencyMaterial,
+            currencyName,
+            amount,
+            System.currentTimeMillis(),
+            context
+        );
+    }
+}

--- a/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
+++ b/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
@@ -143,6 +143,19 @@ public class PendingPayoutStore {
      * rolled back so the store's state matches what is actually on disk.
      */
     public synchronized boolean addPendingPayout(PendingPayout payout) {
+        PendingPayout existing = byId.get(payout.id());
+        if (existing != null) {
+            if (!existing.equals(payout)) {
+                plugin.getLogger().severe("[NCCasino] Refusing pending payout ID collision for "
+                    + payout.id() + ".");
+                return false;
+            }
+            // Retrying the exact same durable operation is a no-op. Without
+            // this guard, byPlayer could contain the record twice and pay it
+            // twice even though byId only contained one copy.
+            return true;
+        }
+
         indexAdd(payout);
 
         boolean ok = persist();

--- a/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
+++ b/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
@@ -1,0 +1,269 @@
+package org.nc.nccasino.payout;
+
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.nc.nccasino.Nccasino;
+import org.nc.nccasino.currency.CurrencyMode;
+import org.nc.nccasino.currency.MoneyHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * Durable, UUID-keyed store for {@link PendingPayout} records, backed by a
+ * dedicated {@code data/pending-payouts.yml} file (deliberately separate
+ * from {@code preferences.yml} — this is money-bearing state, not a sound/
+ * message preference). Survives server restarts between when a
+ * disconnected player's outcome is calculated and when they reconnect.
+ *
+ * <p>Write ordering is deliberate throughout:
+ * <ul>
+ *   <li>{@link #addPendingPayout} only reports success once the record is
+ *       actually written to disk — callers must not clear their in-memory
+ *       game state unless this returns {@code true}, so a failed write
+ *       never silently drops a payout.</li>
+ *   <li>{@link #attemptDeliver} only removes a record (and persists that
+ *       removal) after the actual currency deposit succeeds — a failed
+ *       deposit leaves the record pending for a later retry rather than
+ *       losing it.</li>
+ * </ul>
+ */
+public class PendingPayoutStore {
+
+    private final Nccasino plugin;
+    private final File file;
+    private final Map<UUID, PendingPayout> byId = new LinkedHashMap<>();
+    private final Map<UUID, List<PendingPayout>> byPlayer = new HashMap<>();
+
+    public PendingPayoutStore(Nccasino plugin) {
+        this.plugin = plugin;
+
+        File dataFolder = new File(plugin.getDataFolder(), "data");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+        this.file = new File(dataFolder, "pending-payouts.yml");
+
+        load();
+    }
+
+    private synchronized void load() {
+        byId.clear();
+        byPlayer.clear();
+
+        if (!file.exists()) {
+            return;
+        }
+
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        ConfigurationSection section = config.getConfigurationSection("payouts");
+        if (section == null) {
+            return;
+        }
+
+        for (String idKey : section.getKeys(false)) {
+            try {
+                UUID id = UUID.fromString(idKey);
+                UUID playerId = UUID.fromString(section.getString(idKey + ".player"));
+                String gameType = section.getString(idKey + ".game-type", "");
+                String dealer = section.getString(idKey + ".dealer", null);
+                CurrencyMode mode = CurrencyMode.valueOf(section.getString(idKey + ".currency-mode", "STANDARD"));
+                String material = section.getString(idKey + ".currency-material", null);
+                String currencyName = section.getString(idKey + ".currency-name", "");
+                double amount = section.getDouble(idKey + ".amount", 0);
+                long createdAt = section.getLong(idKey + ".created-at", System.currentTimeMillis());
+                String context = section.getString(idKey + ".context", "");
+
+                PendingPayout payout = new PendingPayout(
+                    id, playerId, gameType, dealer, mode, material, currencyName, amount, createdAt, context);
+                indexAdd(payout);
+            } catch (IllegalArgumentException | NullPointerException e) {
+                plugin.getLogger().log(Level.WARNING,
+                    "[NCCasino] Skipping malformed pending payout record '" + idKey + "' in pending-payouts.yml", e);
+            }
+        }
+    }
+
+    private synchronized boolean persist() {
+        FileConfiguration config = new YamlConfiguration();
+        for (PendingPayout payout : byId.values()) {
+            String base = "payouts." + payout.id();
+            config.set(base + ".player", payout.playerId().toString());
+            config.set(base + ".game-type", payout.gameType());
+            config.set(base + ".dealer", payout.dealerInternalName());
+            config.set(base + ".currency-mode", payout.currencyMode().name());
+            config.set(base + ".currency-material", payout.currencyMaterial());
+            config.set(base + ".currency-name", payout.currencyName());
+            config.set(base + ".amount", payout.amount());
+            config.set(base + ".created-at", payout.createdAtEpochMillis());
+            config.set(base + ".context", payout.context());
+        }
+
+        try {
+            config.save(file);
+            return true;
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "[NCCasino] Failed to save pending-payouts.yml", e);
+            return false;
+        }
+    }
+
+    private void indexAdd(PendingPayout payout) {
+        byId.put(payout.id(), payout);
+        byPlayer.computeIfAbsent(payout.playerId(), k -> new ArrayList<>()).add(payout);
+    }
+
+    private void indexRemove(PendingPayout payout) {
+        byId.remove(payout.id());
+        List<PendingPayout> list = byPlayer.get(payout.playerId());
+        if (list != null) {
+            list.remove(payout);
+            if (list.isEmpty()) {
+                byPlayer.remove(payout.playerId());
+            }
+        }
+    }
+
+    /**
+     * Durably persists a new pending payout. Only returns {@code true} if
+     * the write to disk succeeded; on failure the in-memory addition is
+     * rolled back so the store's state matches what is actually on disk.
+     */
+    public synchronized boolean addPendingPayout(PendingPayout payout) {
+        indexAdd(payout);
+
+        boolean ok = persist();
+        if (!ok) {
+            indexRemove(payout);
+        }
+        return ok;
+    }
+
+    public synchronized List<PendingPayout> getPending(UUID playerId) {
+        return List.copyOf(byPlayer.getOrDefault(playerId, List.of()));
+    }
+
+    public synchronized boolean hasPending(UUID playerId) {
+        List<PendingPayout> list = byPlayer.get(playerId);
+        return list != null && !list.isEmpty();
+    }
+
+    /**
+     * Removes a delivered record and persists the removal. Idempotent: if
+     * the record is already gone, this is a harmless no-op that still
+     * reports success.
+     */
+    private synchronized boolean markDelivered(UUID payoutId) {
+        PendingPayout removed = byId.get(payoutId);
+        if (removed == null) {
+            return true;
+        }
+
+        indexRemove(removed);
+
+        boolean ok = persist();
+        if (!ok) {
+            // Roll back so we don't lose track of a record that is, from
+            // disk's perspective, still pending.
+            indexAdd(removed);
+        }
+        return ok;
+    }
+
+    /**
+     * Attempts to deliver every pending payout currently on record for
+     * {@code player}. A record with {@code amount() <= 0} needs no
+     * currency movement and is always delivered immediately (there is
+     * nothing that can fail). A record with a positive amount is only
+     * removed from the store if the actual deposit succeeds; on failure it
+     * is left pending for a later retry and logged.
+     */
+    public synchronized DeliveryResult attemptDeliver(Player player) {
+        List<PendingPayout> pending = getPending(player.getUniqueId());
+        List<PendingPayout> delivered = new ArrayList<>();
+        List<PendingPayout> stillPending = new ArrayList<>();
+
+        for (PendingPayout payout : pending) {
+            boolean depositOk = payout.amount() <= 0 || depositCurrency(player, payout);
+            if (!depositOk) {
+                stillPending.add(payout);
+                plugin.getLogger().warning("[NCCasino] Could not deliver pending payout " + payout.id()
+                    + " (" + payout.amount() + " " + payout.currencyMode() + ") to " + player.getUniqueId()
+                    + "; left pending for retry.");
+                continue;
+            }
+
+            if (markDelivered(payout.id())) {
+                delivered.add(payout);
+            } else {
+                // Removal failed to persist; treat as not-yet-delivered
+                // rather than risk double-crediting on a later retry.
+                stillPending.add(payout);
+            }
+        }
+
+        return new DeliveryResult(delivered, stillPending);
+    }
+
+    private boolean depositCurrency(Player player, PendingPayout payout) {
+        try {
+            if (payout.currencyMode() == CurrencyMode.VAULT) {
+                return depositVault(player, payout);
+            }
+            return depositItems(player, payout);
+        } catch (RuntimeException e) {
+            plugin.getLogger().log(Level.SEVERE,
+                "[NCCasino] Exception delivering pending payout " + payout.id(), e);
+            return false;
+        }
+    }
+
+    private boolean depositVault(Player player, PendingPayout payout) {
+        if (plugin.getVaultHook() == null || !plugin.getVaultHook().isEconomyAvailable()) {
+            return false;
+        }
+
+        Economy economy = plugin.getVaultHook().getEconomy();
+        double amount = MoneyHelper.toVaultDouble(MoneyHelper.bd(payout.amount()));
+        if (amount <= 0) {
+            return true;
+        }
+
+        EconomyResponse resp = economy.depositPlayer(player, amount);
+        return resp != null && resp.transactionSuccess();
+    }
+
+    private boolean depositItems(Player player, PendingPayout payout) {
+        Material material = payout.currencyMaterial() != null
+            ? Material.matchMaterial(payout.currencyMaterial())
+            : null;
+        if (material == null) {
+            return false;
+        }
+
+        int wholeAmount = (int) payout.amount();
+        if (wholeAmount <= 0) {
+            return true;
+        }
+
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(new ItemStack(material, wholeAmount));
+        if (!leftover.isEmpty()) {
+            int leftoverAmount = leftover.values().stream().mapToInt(ItemStack::getAmount).sum();
+            player.getWorld().dropItemNaturally(player.getLocation(), new ItemStack(material, leftoverAmount));
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
+++ b/src/main/java/org/nc/nccasino/payout/PendingPayoutStore.java
@@ -162,25 +162,33 @@ public class PendingPayoutStore {
     }
 
     /**
-     * Removes a delivered record and persists the removal. Idempotent: if
-     * the record is already gone, this is a harmless no-op that still
-     * reports success.
+     * Removes a record whose payout has ALREADY been delivered (the
+     * currency has already moved) and persists the removal. Idempotent: if
+     * the record is already gone, this is a harmless no-op.
+     *
+     * <p>Unlike a normal removal, this deliberately never rolls back the
+     * in-memory removal on a persist failure. By the time this is called
+     * the player has already been paid — re-adding the record so it looks
+     * pending again would make the next {@link #attemptDeliver} call pay
+     * them a second time, which is strictly worse than the alternative: a
+     * stale, already-delivered record surviving on disk that needs manual
+     * cleanup (logged loudly below) but can never cause a duplicate
+     * payment from this running instance.
      */
-    private synchronized boolean markDelivered(UUID payoutId) {
+    private synchronized void markDelivered(UUID payoutId) {
         PendingPayout removed = byId.get(payoutId);
         if (removed == null) {
-            return true;
+            return;
         }
 
         indexRemove(removed);
 
-        boolean ok = persist();
-        if (!ok) {
-            // Roll back so we don't lose track of a record that is, from
-            // disk's perspective, still pending.
-            indexAdd(removed);
+        if (!persist()) {
+            plugin.getLogger().log(Level.SEVERE, "[NCCasino] Delivered pending payout " + payoutId
+                + " to " + removed.playerId() + " but failed to persist its removal from disk. "
+                + "The record may still be present in pending-payouts.yml and should be removed "
+                + "manually to avoid a duplicate payout on a future server restart.");
         }
-        return ok;
     }
 
     /**
@@ -189,7 +197,9 @@ public class PendingPayoutStore {
      * currency movement and is always delivered immediately (there is
      * nothing that can fail). A record with a positive amount is only
      * removed from the store if the actual deposit succeeds; on failure it
-     * is left pending for a later retry and logged.
+     * is left pending for a later retry and logged. A deposit that
+     * succeeds is always reported as delivered, even if persisting its
+     * removal from disk fails afterward — see {@link #markDelivered}.
      */
     public synchronized DeliveryResult attemptDeliver(Player player) {
         List<PendingPayout> pending = getPending(player.getUniqueId());
@@ -206,13 +216,8 @@ public class PendingPayoutStore {
                 continue;
             }
 
-            if (markDelivered(payout.id())) {
-                delivered.add(payout);
-            } else {
-                // Removal failed to persist; treat as not-yet-delivered
-                // rather than risk double-crediting on a later retry.
-                stillPending.add(payout);
-            }
+            markDelivered(payout.id());
+            delivered.add(payout);
         }
 
         return new DeliveryResult(delivered, stillPending);

--- a/src/main/java/org/nc/nccasino/session/ExitReason.java
+++ b/src/main/java/org/nc/nccasino/session/ExitReason.java
@@ -1,0 +1,40 @@
+package org.nc.nccasino.session;
+
+/**
+ * Why a player's active game session is being torn down. Drives per-game
+ * wager policy in {@link TerminableSession#onSessionTerminated}.
+ */
+public enum ExitReason {
+    /**
+     * Player disconnected: voluntary quit, client crash, Alt+F4, Wi-Fi
+     * loss, timeout, or a Geyser/Bedrock drop. NCCasino cannot and does
+     * not try to distinguish these at the API level — they all surface as
+     * the same {@code PlayerQuitEvent}.
+     */
+    DISCONNECTED,
+
+    /**
+     * Player was removed by a (non-cancelled) kick. Never entitled to a
+     * refund, deferred payout, or cash-out, regardless of game phase.
+     */
+    KICKED,
+
+    /**
+     * Player deliberately exited the game UI (e.g. clicked "Exit") while
+     * still connected. Distinct from simply navigating between NCCasino
+     * menus, which never reaches session termination at all.
+     */
+    VOLUNTARY_INVENTORY_CLOSE,
+
+    /**
+     * The round/game finished normally; the session is being released as
+     * part of ordinary completion, not because the player left.
+     */
+    GAME_COMPLETED,
+
+    /**
+     * The plugin is disabling (server shutdown, external reload) while
+     * the session was still active.
+     */
+    PLUGIN_DISABLE
+}

--- a/src/main/java/org/nc/nccasino/session/GameTerminationPolicy.java
+++ b/src/main/java/org/nc/nccasino/session/GameTerminationPolicy.java
@@ -1,0 +1,115 @@
+package org.nc.nccasino.session;
+
+import static org.nc.nccasino.session.TerminationAction.CASH_OUT;
+import static org.nc.nccasino.session.TerminationAction.FORFEIT;
+import static org.nc.nccasino.session.TerminationAction.NO_ACTION;
+import static org.nc.nccasino.session.TerminationAction.QUEUE_KNOWN_PAYOUT;
+import static org.nc.nccasino.session.TerminationAction.REFUND;
+import static org.nc.nccasino.session.TerminationAction.RIDE_TO_RESULT;
+
+/**
+ * Pure, deterministic disconnect policy for each game.
+ *
+ * <p>The game objects remain responsible for translating their live state
+ * into these small phase inputs and carrying out the returned action. This
+ * class deliberately knows nothing about Bukkit, inventories, or timers.
+ */
+public final class GameTerminationPolicy {
+
+    public enum MinesPhase {
+        PREGAME,
+        PLAYING,
+        GAME_OVER_DEPOSIT_PENDING,
+        RESOLVED
+    }
+
+    private GameTerminationPolicy() {
+    }
+
+    public static TerminationAction blackjack(ExitReason reason, boolean gameActive) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        if (reason == ExitReason.PLUGIN_DISABLE) {
+            return REFUND;
+        }
+        if (gameActive) {
+            return FORFEIT;
+        }
+        return REFUND;
+    }
+
+    public static TerminationAction mines(ExitReason reason, MinesPhase phase) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        return switch (phase) {
+            case PREGAME -> REFUND;
+            case PLAYING -> CASH_OUT;
+            case GAME_OVER_DEPOSIT_PENDING -> CASH_OUT;
+            case RESOLVED -> NO_ACTION;
+        };
+    }
+
+    public static TerminationAction dragon(
+        ExitReason reason,
+        boolean bettingEnabled,
+        boolean playerLost
+    ) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        if (bettingEnabled) {
+            return REFUND;
+        }
+        return playerLost ? NO_ACTION : CASH_OUT;
+    }
+
+    public static TerminationAction roulette(ExitReason reason, boolean knownPayoutPending) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        if (reason == ExitReason.PLUGIN_DISABLE || knownPayoutPending) {
+            return knownPayoutPending ? QUEUE_KNOWN_PAYOUT : REFUND;
+        }
+        return RIDE_TO_RESULT;
+    }
+
+    public static TerminationAction baccarat(ExitReason reason, boolean waitingForRound) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        if (waitingForRound || reason == ExitReason.PLUGIN_DISABLE) {
+            return REFUND;
+        }
+        return RIDE_TO_RESULT;
+    }
+
+    public static TerminationAction coinFlip(ExitReason reason, boolean gameActive) {
+        if (reason == ExitReason.GAME_COMPLETED) {
+            return NO_ACTION;
+        }
+        if (reason == ExitReason.KICKED) {
+            return FORFEIT;
+        }
+        if (!gameActive || reason == ExitReason.PLUGIN_DISABLE) {
+            return REFUND;
+        }
+        return RIDE_TO_RESULT;
+    }
+}

--- a/src/main/java/org/nc/nccasino/session/SessionRegistry.java
+++ b/src/main/java/org/nc/nccasino/session/SessionRegistry.java
@@ -1,0 +1,106 @@
+package org.nc.nccasino.session;
+
+import org.bukkit.Bukkit;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Central, UUID-keyed, idempotent entry point for tearing down a player's
+ * active game session. Games register themselves as the current owner of a
+ * player's session when that player enters a wager-bearing state, and
+ * unregister when it resolves normally.
+ *
+ * <p>{@link #terminatePlayerSession} is the single path every disconnect,
+ * kick, plugin-shutdown, or voluntary-exit route should funnel through, so
+ * a given session is only ever resolved once — regardless of how many
+ * events fire around it (Kick, Quit, InventoryClose) or in what order.
+ * Idempotency comes from {@link Map#remove(Object)} being atomic: whichever
+ * caller removes the registration first is the only one that does any
+ * work, every later call for the same UUID finds nothing and no-ops.
+ */
+public final class SessionRegistry {
+
+    private static final Map<UUID, TerminableSession> activeSessions = new ConcurrentHashMap<>();
+    private static final Set<UUID> pendingKick = ConcurrentHashMap.newKeySet();
+
+    private SessionRegistry() {
+    }
+
+    /**
+     * Registers {@code session} as the current owner of {@code playerId}'s
+     * active game session. Overwrites any previous registration for the
+     * same UUID — a new session always supersedes a stale one.
+     */
+    public static void register(UUID playerId, TerminableSession session) {
+        activeSessions.put(playerId, session);
+    }
+
+    /**
+     * Clears the registration for {@code playerId}, but only if it still
+     * points at {@code session}. Prevents a late unregister call from a
+     * superseded session clobbering a newer one already registered for the
+     * same UUID.
+     */
+    public static void unregister(UUID playerId, TerminableSession session) {
+        activeSessions.remove(playerId, session);
+    }
+
+    public static boolean hasActiveSession(UUID playerId) {
+        return activeSessions.containsKey(playerId);
+    }
+
+    /** Records that this UUID's next quit was caused by a (non-cancelled) kick. */
+    public static void markKicked(UUID playerId) {
+        pendingKick.add(playerId);
+    }
+
+    /** Clears a pending-kick marker without terminating anything. */
+    public static void clearKickMarker(UUID playerId) {
+        pendingKick.remove(playerId);
+    }
+
+    /**
+     * Consumes and returns the exit reason a quit should be classified as:
+     * {@link ExitReason#KICKED} if this UUID was just marked by a kick,
+     * otherwise {@link ExitReason#DISCONNECTED}. Clears the marker either
+     * way, so it is only ever consumed once per quit.
+     */
+    public static ExitReason consumeQuitReason(UUID playerId) {
+        return pendingKick.remove(playerId) ? ExitReason.KICKED : ExitReason.DISCONNECTED;
+    }
+
+    /**
+     * The single idempotent termination entry point. Safe to call more
+     * than once, from more than one listener, in any order: only the call
+     * that actually finds and removes an active registration performs any
+     * work.
+     */
+    public static void terminatePlayerSession(UUID playerId, ExitReason reason) {
+        TerminableSession session = activeSessions.remove(playerId);
+        if (session == null) {
+            return;
+        }
+        try {
+            session.onSessionTerminated(playerId, reason);
+        } catch (RuntimeException e) {
+            Bukkit.getLogger().log(Level.SEVERE,
+                "[NCCasino] Failed to terminate session for " + playerId + " (" + reason + ")", e);
+        }
+    }
+
+    /**
+     * Terminates every currently active session with {@code reason},
+     * isolating failures per player so one broken session does not stop
+     * the rest from being resolved. Intended for plugin shutdown.
+     */
+    public static void terminateAll(ExitReason reason) {
+        for (UUID playerId : new ArrayList<>(activeSessions.keySet())) {
+            terminatePlayerSession(playerId, reason);
+        }
+    }
+}

--- a/src/main/java/org/nc/nccasino/session/TerminableSession.java
+++ b/src/main/java/org/nc/nccasino/session/TerminableSession.java
@@ -1,0 +1,28 @@
+package org.nc.nccasino.session;
+
+import java.util.UUID;
+
+/**
+ * Implemented by whatever object currently owns a player's active
+ * wager-bearing game state (a {@code Client}, a per-player table, etc.) so
+ * {@link SessionRegistry} can delegate wager resolution and seat release
+ * back to the right game without knowing that game's internals.
+ *
+ * <p>This is strictly about resolving the session's outcome (refund,
+ * forfeit, cash-out, deferred payout) and releasing shared state (seat,
+ * maps). UI teardown — unregistering listeners, closing inventories — is a
+ * separate concern each game already owns and may perform independently of
+ * this callback.
+ */
+public interface TerminableSession {
+
+    /**
+     * Resolve and release this player's session for the given reason.
+     * {@link SessionRegistry} guarantees this is invoked at most once per
+     * {@link SessionRegistry#register} call, but implementations should
+     * still guard their own state changes defensively rather than assume
+     * this is the only possible way their session ends, since a normal
+     * game-completion path can run concurrently with disconnect handling.
+     */
+    void onSessionTerminated(UUID playerId, ExitReason reason);
+}

--- a/src/main/java/org/nc/nccasino/session/TerminationAction.java
+++ b/src/main/java/org/nc/nccasino/session/TerminationAction.java
@@ -1,0 +1,15 @@
+package org.nc.nccasino.session;
+
+/**
+ * Money-bearing action a game must take when an active session terminates.
+ * Keeping these outcomes explicit makes the policy independently testable
+ * from Bukkit inventories, animations, and schedulers.
+ */
+public enum TerminationAction {
+    NO_ACTION,
+    FORFEIT,
+    REFUND,
+    CASH_OUT,
+    RIDE_TO_RESULT,
+    QUEUE_KNOWN_PAYOUT
+}

--- a/src/test/java/org/nc/nccasino/currency/MoneyHelperTest.java
+++ b/src/test/java/org/nc/nccasino/currency/MoneyHelperTest.java
@@ -1,0 +1,34 @@
+package org.nc.nccasino.currency;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MoneyHelperTest {
+
+    @Test
+    void wagerUnitsAcceptOnlyPositiveWholeValues() {
+        assertEquals(25, MoneyHelper.toWagerUnits(25));
+        assertEquals(25, MoneyHelper.toWagerUnits(25.0000001));
+        assertEquals(0, MoneyHelper.toWagerUnits(25.5));
+        assertEquals(0, MoneyHelper.toWagerUnits(0));
+        assertEquals(0, MoneyHelper.toWagerUnits(-10));
+    }
+
+    @Test
+    void vaultConversionNeverCreatesNegativeDeposit() {
+        assertEquals(12.5, MoneyHelper.toVaultDouble(new BigDecimal("12.5")));
+        assertEquals(0, MoneyHelper.toVaultDouble(new BigDecimal("-0.01")));
+        assertEquals(0, MoneyHelper.toVaultDouble(null));
+    }
+
+    @Test
+    void floorToLongDoesNotOverflowOrGoNegative() {
+        assertEquals(12, MoneyHelper.floorToLong(new BigDecimal("12.99")));
+        assertEquals(0, MoneyHelper.floorToLong(new BigDecimal("-1")));
+        assertEquals(Long.MAX_VALUE,
+            MoneyHelper.floorToLong(new BigDecimal("999999999999999999999999")));
+    }
+}

--- a/src/test/java/org/nc/nccasino/payout/PendingPayoutStoreTest.java
+++ b/src/test/java/org/nc/nccasino/payout/PendingPayoutStoreTest.java
@@ -1,0 +1,264 @@
+package org.nc.nccasino.payout;
+
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.nc.nccasino.Nccasino;
+import org.nc.nccasino.currency.CurrencyMode;
+import org.nc.nccasino.economy.VaultHook;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PendingPayoutStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Nccasino plugin;
+    private VaultHook vaultHook;
+    private Economy economy;
+
+    @BeforeEach
+    void setUp() {
+        plugin = mock(Nccasino.class);
+        vaultHook = mock(VaultHook.class);
+        economy = mock(Economy.class);
+        when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("PendingPayoutStoreTest"));
+        when(plugin.getVaultHook()).thenReturn(vaultHook);
+        when(vaultHook.isEconomyAvailable()).thenReturn(true);
+        when(vaultHook.getEconomy()).thenReturn(economy);
+    }
+
+    @Test
+    void addedPayoutSurvivesStoreReloadWithFullCurrencySnapshot() {
+        UUID playerId = UUID.randomUUID();
+        PendingPayout payout = PendingPayout.create(
+            playerId, "Roulette", "roulette-a", CurrencyMode.CUSTOM,
+            "EMERALD", "Casino Token", 37, "won on red");
+        PendingPayoutStore first = new PendingPayoutStore(plugin);
+
+        assertTrue(first.addPendingPayout(payout));
+        PendingPayoutStore reloaded = new PendingPayoutStore(plugin);
+
+        assertEquals(java.util.List.of(payout), reloaded.getPending(playerId));
+        assertTrue(new File(tempDir.toFile(), "data/pending-payouts.yml").isFile());
+    }
+
+    @Test
+    void zeroValueOutcomeIsDeliveredAndRemovedWithoutTouchingEconomy() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PendingPayout payout = payout(playerId, UUID.randomUUID(), 0);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult result = store.attemptDeliver(player);
+
+        assertEquals(java.util.List.of(payout), result.delivered());
+        assertTrue(result.stillPending().isEmpty());
+        assertFalse(store.hasPending(playerId));
+        verify(economy, never()).depositPlayer(any(Player.class), any(Double.class));
+    }
+
+    @Test
+    void successfulVaultPayoutIsDepositedOnceAndDurablyRemoved() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PendingPayout payout = payout(playerId, UUID.randomUUID(), 50);
+        when(economy.depositPlayer(player, 50.0)).thenReturn(success(50));
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult first = store.attemptDeliver(player);
+        DeliveryResult second = store.attemptDeliver(player);
+
+        assertEquals(java.util.List.of(payout), first.delivered());
+        assertTrue(second.isEmpty());
+        verify(economy, times(1)).depositPlayer(player, 50.0);
+        assertFalse(new PendingPayoutStore(plugin).hasPending(playerId));
+    }
+
+    @Test
+    void failedVaultDepositStaysPendingAndCanSucceedOnRetry() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PendingPayout payout = payout(playerId, UUID.randomUUID(), 25);
+        when(economy.depositPlayer(player, 25.0))
+            .thenReturn(failure(25))
+            .thenReturn(success(25));
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult failed = store.attemptDeliver(player);
+        assertEquals(java.util.List.of(payout), failed.stillPending());
+        assertTrue(store.hasPending(playerId));
+        assertTrue(new PendingPayoutStore(plugin).hasPending(playerId));
+
+        DeliveryResult retried = store.attemptDeliver(player);
+        assertEquals(java.util.List.of(payout), retried.delivered());
+        assertFalse(store.hasPending(playerId));
+        verify(economy, times(2)).depositPlayer(player, 25.0);
+    }
+
+    @Test
+    void addingSameRecordTwiceCannotProduceDuplicatePayment() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PendingPayout payout = payout(playerId, UUID.randomUUID(), 10);
+        when(economy.depositPlayer(player, 10.0)).thenReturn(success(10));
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+
+        assertTrue(store.addPendingPayout(payout));
+        assertTrue(store.addPendingPayout(payout));
+        assertEquals(1, store.getPending(playerId).size());
+        store.attemptDeliver(player);
+
+        verify(economy, times(1)).depositPlayer(player, 10.0);
+    }
+
+    @Test
+    void collidingIdWithDifferentContentsIsRejectedWithoutReplacingOriginal() {
+        UUID playerId = UUID.randomUUID();
+        UUID payoutId = UUID.randomUUID();
+        PendingPayout original = payout(playerId, payoutId, 10);
+        PendingPayout collision = payout(playerId, payoutId, 999);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+
+        assertTrue(store.addPendingPayout(original));
+        assertFalse(store.addPendingPayout(collision));
+
+        assertEquals(java.util.List.of(original), store.getPending(playerId));
+    }
+
+    @Test
+    void payoutForDifferentPlayerIsNotDeliveredOnThisJoin() {
+        UUID owedPlayer = UUID.randomUUID();
+        PendingPayout payout = payout(owedPlayer, UUID.randomUUID(), 15);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult result = store.attemptDeliver(player(UUID.randomUUID()));
+
+        assertTrue(result.isEmpty());
+        assertTrue(store.hasPending(owedPlayer));
+        verify(economy, never()).depositPlayer(any(Player.class), eq(15.0));
+    }
+
+    @Test
+    void standardItemPayoutAddsSnapshottedMaterialToInventory() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inventory);
+        when(inventory.addItem(any(ItemStack[].class))).thenReturn(new HashMap<>());
+        PendingPayout payout = itemPayout(playerId, "EMERALD", 32);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult result = store.attemptDeliver(player);
+
+        assertEquals(java.util.List.of(payout), result.delivered());
+        verify(inventory).addItem(argThat((ItemStack item) ->
+            item.getType() == Material.EMERALD && item.getAmount() == 32));
+        assertFalse(store.hasPending(playerId));
+    }
+
+    @Test
+    void itemOverflowDropsRemainderAtPlayerLocationInsteadOfLosingIt() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        World world = mock(World.class);
+        Location location = mock(Location.class);
+        when(player.getInventory()).thenReturn(inventory);
+        when(player.getWorld()).thenReturn(world);
+        when(player.getLocation()).thenReturn(location);
+        HashMap<Integer, ItemStack> leftover = new HashMap<>();
+        leftover.put(0, new ItemStack(Material.EMERALD, 7));
+        when(inventory.addItem(any(ItemStack[].class))).thenReturn(leftover);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(itemPayout(playerId, "EMERALD", 32)));
+
+        store.attemptDeliver(player);
+
+        verify(world).dropItemNaturally(eq(location), argThat(item ->
+            item.getType() == Material.EMERALD && item.getAmount() == 7));
+    }
+
+    @Test
+    void invalidSnapshottedMaterialLeavesPayoutPending() {
+        UUID playerId = UUID.randomUUID();
+        Player player = player(playerId);
+        PendingPayout payout = itemPayout(playerId, "NOT_A_REAL_MATERIAL", 5);
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+        assertTrue(store.addPendingPayout(payout));
+
+        DeliveryResult result = store.attemptDeliver(player);
+
+        assertEquals(java.util.List.of(payout), result.stillPending());
+        assertTrue(store.hasPending(playerId));
+    }
+
+    @Test
+    void failedDiskWriteRollsBackInMemoryAddition() throws Exception {
+        File blockedDataFolder = Files.createFile(tempDir.resolve("not-a-directory")).toFile();
+        when(plugin.getDataFolder()).thenReturn(blockedDataFolder);
+        UUID playerId = UUID.randomUUID();
+        PendingPayoutStore store = new PendingPayoutStore(plugin);
+
+        assertFalse(store.addPendingPayout(payout(playerId, UUID.randomUUID(), 10)));
+        assertFalse(store.hasPending(playerId));
+    }
+
+    private Player player(UUID playerId) {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        return player;
+    }
+
+    private PendingPayout payout(UUID playerId, UUID payoutId, double amount) {
+        return new PendingPayout(
+            payoutId, playerId, "Roulette", "roulette-a", CurrencyMode.VAULT,
+            null, "Dollar", amount, 123456789L, "test outcome");
+    }
+
+    private PendingPayout itemPayout(UUID playerId, String material, double amount) {
+        return new PendingPayout(
+            UUID.randomUUID(), playerId, "Mines", "mines-a", CurrencyMode.STANDARD,
+            material, "Emerald", amount, 123456789L, "test item payout");
+    }
+
+    private EconomyResponse success(double amount) {
+        return new EconomyResponse(amount, amount, EconomyResponse.ResponseType.SUCCESS, null);
+    }
+
+    private EconomyResponse failure(double amount) {
+        return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.FAILURE, "test failure");
+    }
+}

--- a/src/test/java/org/nc/nccasino/session/GameTerminationPolicyTest.java
+++ b/src/test/java/org/nc/nccasino/session/GameTerminationPolicyTest.java
@@ -1,0 +1,135 @@
+package org.nc.nccasino.session;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.nc.nccasino.session.GameTerminationPolicy.MinesPhase.GAME_OVER_DEPOSIT_PENDING;
+import static org.nc.nccasino.session.GameTerminationPolicy.MinesPhase.PLAYING;
+import static org.nc.nccasino.session.GameTerminationPolicy.MinesPhase.PREGAME;
+import static org.nc.nccasino.session.GameTerminationPolicy.MinesPhase.RESOLVED;
+import static org.nc.nccasino.session.TerminationAction.CASH_OUT;
+import static org.nc.nccasino.session.TerminationAction.FORFEIT;
+import static org.nc.nccasino.session.TerminationAction.NO_ACTION;
+import static org.nc.nccasino.session.TerminationAction.QUEUE_KNOWN_PAYOUT;
+import static org.nc.nccasino.session.TerminationAction.REFUND;
+import static org.nc.nccasino.session.TerminationAction.RIDE_TO_RESULT;
+
+class GameTerminationPolicyTest {
+
+    @Test
+    void kicksAlwaysForfeitAcrossEveryGameAndPhase() {
+        assertEquals(FORFEIT, GameTerminationPolicy.blackjack(ExitReason.KICKED, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.blackjack(ExitReason.KICKED, true));
+        assertEquals(FORFEIT, GameTerminationPolicy.mines(ExitReason.KICKED, PREGAME));
+        assertEquals(FORFEIT, GameTerminationPolicy.mines(ExitReason.KICKED, PLAYING));
+        assertEquals(FORFEIT, GameTerminationPolicy.dragon(ExitReason.KICKED, true, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.dragon(ExitReason.KICKED, false, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.roulette(ExitReason.KICKED, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.roulette(ExitReason.KICKED, true));
+        assertEquals(FORFEIT, GameTerminationPolicy.baccarat(ExitReason.KICKED, true));
+        assertEquals(FORFEIT, GameTerminationPolicy.baccarat(ExitReason.KICKED, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.coinFlip(ExitReason.KICKED, false));
+        assertEquals(FORFEIT, GameTerminationPolicy.coinFlip(ExitReason.KICKED, true));
+    }
+
+    @Test
+    void blackjackRefundsPregameButForfeitsOnceDealStarts() {
+        for (ExitReason reason : new ExitReason[] {
+            ExitReason.DISCONNECTED,
+            ExitReason.VOLUNTARY_INVENTORY_CLOSE
+        }) {
+            assertEquals(REFUND, GameTerminationPolicy.blackjack(reason, false));
+            assertEquals(FORFEIT, GameTerminationPolicy.blackjack(reason, true));
+        }
+        assertEquals(REFUND,
+            GameTerminationPolicy.blackjack(ExitReason.PLUGIN_DISABLE, false));
+        assertEquals(REFUND,
+            GameTerminationPolicy.blackjack(ExitReason.PLUGIN_DISABLE, true));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.blackjack(ExitReason.GAME_COMPLETED, false));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.blackjack(ExitReason.GAME_COMPLETED, true));
+    }
+
+    @Test
+    void minesRefundsPregameAndCashesOutActivePosition() {
+        for (ExitReason reason : nonKickReasons()) {
+            assertEquals(REFUND, GameTerminationPolicy.mines(reason, PREGAME));
+            assertEquals(CASH_OUT, GameTerminationPolicy.mines(reason, PLAYING));
+            assertEquals(NO_ACTION, GameTerminationPolicy.mines(reason, RESOLVED));
+        }
+        assertEquals(CASH_OUT,
+            GameTerminationPolicy.mines(ExitReason.PLUGIN_DISABLE, GAME_OVER_DEPOSIT_PENDING));
+        assertEquals(CASH_OUT,
+            GameTerminationPolicy.mines(ExitReason.DISCONNECTED, GAME_OVER_DEPOSIT_PENDING));
+        for (GameTerminationPolicy.MinesPhase phase : GameTerminationPolicy.MinesPhase.values()) {
+            assertEquals(NO_ACTION,
+                GameTerminationPolicy.mines(ExitReason.GAME_COMPLETED, phase));
+        }
+    }
+
+    @Test
+    void dragonRefundsBeforeStartCashesOutLiveRunAndDoesNothingAfterResolution() {
+        for (ExitReason reason : nonKickReasons()) {
+            assertEquals(REFUND, GameTerminationPolicy.dragon(reason, true, false));
+            assertEquals(CASH_OUT, GameTerminationPolicy.dragon(reason, false, false));
+            assertEquals(NO_ACTION, GameTerminationPolicy.dragon(reason, false, true));
+        }
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.dragon(ExitReason.GAME_COMPLETED, true, false));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.dragon(ExitReason.GAME_COMPLETED, false, false));
+    }
+
+    @Test
+    void rouletteRidesOrdinaryDisconnectButRefundsShutdown() {
+        assertEquals(RIDE_TO_RESULT,
+            GameTerminationPolicy.roulette(ExitReason.DISCONNECTED, false));
+        assertEquals(RIDE_TO_RESULT,
+            GameTerminationPolicy.roulette(ExitReason.VOLUNTARY_INVENTORY_CLOSE, false));
+        assertEquals(REFUND,
+            GameTerminationPolicy.roulette(ExitReason.PLUGIN_DISABLE, false));
+        assertEquals(QUEUE_KNOWN_PAYOUT,
+            GameTerminationPolicy.roulette(ExitReason.PLUGIN_DISABLE, true));
+        assertEquals(QUEUE_KNOWN_PAYOUT,
+            GameTerminationPolicy.roulette(ExitReason.DISCONNECTED, true));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.roulette(ExitReason.GAME_COMPLETED, false));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.roulette(ExitReason.GAME_COMPLETED, true));
+    }
+
+    @Test
+    void baccaratRefundsPregameRidesActiveHandAndRefundsShutdown() {
+        assertEquals(REFUND, GameTerminationPolicy.baccarat(ExitReason.DISCONNECTED, true));
+        assertEquals(RIDE_TO_RESULT,
+            GameTerminationPolicy.baccarat(ExitReason.DISCONNECTED, false));
+        assertEquals(REFUND,
+            GameTerminationPolicy.baccarat(ExitReason.PLUGIN_DISABLE, false));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.baccarat(ExitReason.GAME_COMPLETED, true));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.baccarat(ExitReason.GAME_COMPLETED, false));
+    }
+
+    @Test
+    void coinFlipRefundsPregameRidesAcceptedFlipAndRefundsShutdown() {
+        assertEquals(REFUND, GameTerminationPolicy.coinFlip(ExitReason.DISCONNECTED, false));
+        assertEquals(RIDE_TO_RESULT,
+            GameTerminationPolicy.coinFlip(ExitReason.DISCONNECTED, true));
+        assertEquals(REFUND,
+            GameTerminationPolicy.coinFlip(ExitReason.PLUGIN_DISABLE, true));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.coinFlip(ExitReason.GAME_COMPLETED, false));
+        assertEquals(NO_ACTION,
+            GameTerminationPolicy.coinFlip(ExitReason.GAME_COMPLETED, true));
+    }
+
+    private static ExitReason[] nonKickReasons() {
+        return new ExitReason[] {
+            ExitReason.DISCONNECTED,
+            ExitReason.VOLUNTARY_INVENTORY_CLOSE,
+            ExitReason.PLUGIN_DISABLE
+        };
+    }
+}

--- a/src/test/java/org/nc/nccasino/session/SessionRegistryTest.java
+++ b/src/test/java/org/nc/nccasino/session/SessionRegistryTest.java
@@ -1,0 +1,101 @@
+package org.nc.nccasino.session;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionRegistryTest {
+
+    @Test
+    void terminationIsExactlyOnceAndPassesThroughReason() {
+        UUID playerId = UUID.randomUUID();
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<ExitReason> received = new AtomicReference<>();
+        SessionRegistry.register(playerId, (id, reason) -> {
+            assertEquals(playerId, id);
+            calls.incrementAndGet();
+            received.set(reason);
+        });
+
+        SessionRegistry.terminatePlayerSession(playerId, ExitReason.DISCONNECTED);
+        SessionRegistry.terminatePlayerSession(playerId, ExitReason.KICKED);
+
+        assertEquals(1, calls.get());
+        assertEquals(ExitReason.DISCONNECTED, received.get());
+        assertFalse(SessionRegistry.hasActiveSession(playerId));
+    }
+
+    @Test
+    void staleUnregisterCannotRemoveReplacementSession() {
+        UUID playerId = UUID.randomUUID();
+        AtomicInteger replacementCalls = new AtomicInteger();
+        TerminableSession stale = (id, reason) -> { };
+        TerminableSession replacement = (id, reason) -> replacementCalls.incrementAndGet();
+
+        SessionRegistry.register(playerId, stale);
+        SessionRegistry.register(playerId, replacement);
+        SessionRegistry.unregister(playerId, stale);
+
+        assertTrue(SessionRegistry.hasActiveSession(playerId));
+        SessionRegistry.terminatePlayerSession(playerId, ExitReason.GAME_COMPLETED);
+        assertEquals(1, replacementCalls.get());
+    }
+
+    @Test
+    void matchingUnregisterClearsSessionWithoutResolvingIt() {
+        UUID playerId = UUID.randomUUID();
+        AtomicInteger calls = new AtomicInteger();
+        TerminableSession session = (id, reason) -> calls.incrementAndGet();
+        SessionRegistry.register(playerId, session);
+
+        SessionRegistry.unregister(playerId, session);
+        SessionRegistry.terminatePlayerSession(playerId, ExitReason.DISCONNECTED);
+
+        assertEquals(0, calls.get());
+        assertFalse(SessionRegistry.hasActiveSession(playerId));
+    }
+
+    @Test
+    void kickMarkerIsConsumedOnlyOnce() {
+        UUID playerId = UUID.randomUUID();
+        SessionRegistry.markKicked(playerId);
+
+        assertEquals(ExitReason.KICKED, SessionRegistry.consumeQuitReason(playerId));
+        assertEquals(ExitReason.DISCONNECTED, SessionRegistry.consumeQuitReason(playerId));
+    }
+
+    @Test
+    void clearingKickMarkerPreventsLaterMisclassification() {
+        UUID playerId = UUID.randomUUID();
+        SessionRegistry.markKicked(playerId);
+        SessionRegistry.clearKickMarker(playerId);
+        assertEquals(ExitReason.DISCONNECTED, SessionRegistry.consumeQuitReason(playerId));
+    }
+
+    @Test
+    void terminateAllResolvesEveryRegisteredPlayer() {
+        AtomicInteger calls = new AtomicInteger();
+        UUID first = UUID.randomUUID();
+        UUID second = UUID.randomUUID();
+        SessionRegistry.register(first, (id, reason) -> {
+            assertEquals(ExitReason.PLUGIN_DISABLE, reason);
+            calls.incrementAndGet();
+        });
+        SessionRegistry.register(second, (id, reason) -> {
+            assertEquals(ExitReason.PLUGIN_DISABLE, reason);
+            calls.incrementAndGet();
+        });
+
+        SessionRegistry.terminateAll(ExitReason.PLUGIN_DISABLE);
+
+        assertEquals(2, calls.get());
+        assertFalse(SessionRegistry.hasActiveSession(first));
+        assertFalse(SessionRegistry.hasActiveSession(second));
+    }
+}


### PR DESCRIPTION
## What

- centralize deterministic quit, kick, inventory-close, and shutdown settlement policy across Blackjack, Mines, Dragon Descent, Roulette, Baccarat, and Coin Flip
- persist offline and interrupted payouts for delivery on reconnect
- make pending-payout insertion idempotent and reject payout-ID collisions
- close delayed-resolution gaps where a known result could be refunded, lost, or paid twice
- make Coin Flip finish an accepted round even if both clients disconnect
- add JUnit 5/Mockito coverage for termination policy, session routing, pending-payout persistence/delivery, and money rounding

## Why / root cause

Game inventories previously handled termination independently, often through inventory-close behavior and delayed Bukkit tasks. Real quits, kicks, and plugin shutdown could therefore take different paths. Some tasks also separated an authoritative game result from its accounting by several ticks, allowing shutdown or disconnect in that interval to lose, duplicate, or incorrectly refund money.

## Behavior and impact

- kicks forfeit committed wagers
- pregame ordinary exits refund
- active game disconnects either forfeit, cash out, or ride to the authoritative result according to the game's rules
- clean shutdown refunds unresolved wagers through the durable pending-payout store
- if Roulette or Coin Flip already has an authoritative result, shutdown preserves that real payout instead of replacing it with a wager refund
- targets Spigot/Minecraft 1.21.11 and Java 21

## Verification

- `./gradlew.bat clean test build --console=plain`
- 27 tests, 0 failures, 0 errors
- `git diff --check`
- manual Java/Prism testing: normal closes, disconnects, kicks, reconnect delivery, Coin Flip seating/promotion, and general gameplay

## Remaining manual check before ready

- repeat the reconnect/pending-payout smoke test from a Bedrock/Geyser account; this is why the PR is initially a draft
